### PR TITLE
Use the host MAKEFLAGS variable in containers

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -131,7 +131,7 @@ docker pull $docker_repo:$docker_image
 def docker_script(platform, entrypoint, entrypoint_arguments='') {
     def docker_image = get_docker_tag(platform)
     return """\
-docker run -u \$(id -u):\$(id -g) --rm --entrypoint $entrypoint \
+docker run -u \$(id -u):\$(id -g) -e MAKEFLAGS --rm --entrypoint $entrypoint \
     -w /var/lib/build -v `pwd`/src:/var/lib/build \
     --cap-add SYS_PTRACE $docker_repo:$docker_image $entrypoint_arguments
 """


### PR DESCRIPTION
Currently we aren't passing any host variables through to the docker containers, meaning that we were only building the library with `make -j2` on FreeBSD and Windows.

Test runs with the patch applied:
mbedtls-release-ci-testing:  https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/397/
mbed-tls-pr-test-parametrized: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/240/
