### PR TITLE
Enable FreeBSD test on OpenCI

### DIFF
--- a/vars/environ.groovy
+++ b/vars/environ.groovy
@@ -41,7 +41,7 @@ def set_tls_pr_environment(is_production) {
 
 def set_common_pr_production_environment() {
     env.CHECKOUT_METHOD = 'scm'
-    env.RUN_FREEBSD = common.is_open_ci_env ? 'false' : 'true'
+    env.RUN_FREEBSD = 'true'
     env.RUN_WINDOWS_TEST = common.is_open_ci_env ? 'false' : 'true'
     env.RUN_ALL_SH = 'true'
     if (!env.BRANCH_NAME.contains('-head')) {


### PR DESCRIPTION
Signed-off-by: Arthur She <arthur.she@linaro.org>

Test job on the staging CI
[mbedtls-release-ci-testing](https://ci.staging.trustedfirmware.org/view/Arthur%20MbedTLS/job/arthur-mbedtls-release-ci-testing/10/console)
[mbed-tls-restricted-pr-test-parametrized](https://ci.staging.trustedfirmware.org/view/Arthur%20MbedTLS/job/arthur-mbed-tls-restricted-pr-test-parametrized/4/console)