### PR TITLE
fix armcc license fail

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -121,7 +121,7 @@ RUN wget -q https://developer.arm.com/-/media/Files/downloads/compiler/DS500-PA-
 
 ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
 ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
-ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56:1661@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic07.euhpc.arm.com:7010@euhpc-lic03.euhpc.arm.com:7010@euhpc-lic04.euhpc.arm.com:8224@blr-lic05.blr.arm.com:7010@nahpc-lic09.nahpc.arm.com:7010@nahpc-lic06.nahpc.arm.com:8224@blr-lic03.blr.arm.com:224@blr-lic04.blr.arm.com
+ARG ARMLMD_LICENSE_FILE=7010@euhpc-lic04.euhpc.arm.com:7010@euhpc-lic06.euhpc.arm.com:7010@euhpc-lic07.euhpc.arm.com:7010@euhpc-lic03.euhpc.arm.com:7010@aphpc-lic04.ap01.arm.com:7010@aphpc-lic05.ap01.arm.com:7010@nahpc-lic09.nahpc.arm.com:7010@nahpc-lic06.nahpc.arm.com:7010@aphpc-lic03.ap01.arm.com:7010@euhpc-lic-armlmd.euhpc.arm.com
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Install ARM Compiler 6.6

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -121,7 +121,7 @@ RUN wget -q https://developer.arm.com/-/media/Files/downloads/compiler/DS500-PA-
 
 ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
 ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
-ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56
+ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56:1661@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic07.euhpc.arm.com:7010@euhpc-lic03.euhpc.arm.com:7010@euhpc-lic04.euhpc.arm.com:8224@blr-lic05.blr.arm.com:7010@nahpc-lic09.nahpc.arm.com:7010@nahpc-lic06.nahpc.arm.com:8224@blr-lic03.blr.arm.com:224@blr-lic04.blr.arm.com
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Install ARM Compiler 6.6

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -128,7 +128,7 @@ RUN wget -q https://developer.arm.com/-/media/Files/downloads/compiler/DS500-PA-
 
 ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
 ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
-ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56
+ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56:1661@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic07.euhpc.arm.com:7010@euhpc-lic03.euhpc.arm.com:7010@euhpc-lic04.euhpc.arm.com:8224@blr-lic05.blr.arm.com:7010@nahpc-lic09.nahpc.arm.com:7010@nahpc-lic06.nahpc.arm.com:8224@blr-lic03.blr.arm.com:224@blr-lic04.blr.arm.com
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Install ARM Compiler 6.6

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -128,7 +128,7 @@ RUN wget -q https://developer.arm.com/-/media/Files/downloads/compiler/DS500-PA-
 
 ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
 ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
-ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56:1661@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic07.euhpc.arm.com:7010@euhpc-lic03.euhpc.arm.com:7010@euhpc-lic04.euhpc.arm.com:8224@blr-lic05.blr.arm.com:7010@nahpc-lic09.nahpc.arm.com:7010@nahpc-lic06.nahpc.arm.com:8224@blr-lic03.blr.arm.com:224@blr-lic04.blr.arm.com
+ARG ARMLMD_LICENSE_FILE=7010@euhpc-lic04.euhpc.arm.com:7010@euhpc-lic06.euhpc.arm.com:7010@euhpc-lic07.euhpc.arm.com:7010@euhpc-lic03.euhpc.arm.com:7010@aphpc-lic04.ap01.arm.com:7010@aphpc-lic05.ap01.arm.com:7010@nahpc-lic09.nahpc.arm.com:7010@nahpc-lic06.nahpc.arm.com:7010@aphpc-lic03.ap01.arm.com:7010@euhpc-lic-armlmd.euhpc.arm.com
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Install ARM Compiler 6.6

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update -q && apt-get install -yq \
         # for Mbed TLS tests
         abi-compliance-checker \
         # Note that there is a known issue #5332 that stock abi tools
-        # in ubuntu20.04 do not fail as expected. 
+        # in ubuntu20.04 do not fail as expected.
         # https://github.com/ARMmbed/mbedtls/issues/5332
         # Do not activae 20.04 until that is resolved
         # to use with abi-compliance-tester
@@ -127,7 +127,7 @@ RUN wget -q https://developer.arm.com/-/media/Files/downloads/compiler/DS500-PA-
 
 ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
 ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
-ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56
+ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56:1661@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic07.euhpc.arm.com:7010@euhpc-lic03.euhpc.arm.com:7010@euhpc-lic04.euhpc.arm.com:8224@blr-lic05.blr.arm.com:7010@nahpc-lic09.nahpc.arm.com:7010@nahpc-lic06.nahpc.arm.com:8224@blr-lic03.blr.arm.com:224@blr-lic04.blr.arm.com
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Install ARM Compiler 6.6

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update -q && apt-get install -yq \
         # for Mbed TLS tests
         abi-compliance-checker \
         # Note that there is a known issue #5332 that stock abi tools
-        # in ubuntu20.04 do not fail as expected.
+        # in ubuntu20.04 do not fail as expected. 
         # https://github.com/ARMmbed/mbedtls/issues/5332
         # Do not activae 20.04 until that is resolved
         # to use with abi-compliance-tester
@@ -127,7 +127,7 @@ RUN wget -q https://developer.arm.com/-/media/Files/downloads/compiler/DS500-PA-
 
 ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
 ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
-ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56:1661@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic05.euhpc.arm.com:7010@euhpc-lic07.euhpc.arm.com:7010@euhpc-lic03.euhpc.arm.com:7010@euhpc-lic04.euhpc.arm.com:8224@blr-lic05.blr.arm.com:7010@nahpc-lic09.nahpc.arm.com:7010@nahpc-lic06.nahpc.arm.com:8224@blr-lic03.blr.arm.com:224@blr-lic04.blr.arm.com
+ARG ARMLMD_LICENSE_FILE=7010@euhpc-lic04.euhpc.arm.com:7010@euhpc-lic06.euhpc.arm.com:7010@euhpc-lic07.euhpc.arm.com:7010@euhpc-lic03.euhpc.arm.com:7010@aphpc-lic04.ap01.arm.com:7010@aphpc-lic05.ap01.arm.com:7010@nahpc-lic09.nahpc.arm.com:7010@nahpc-lic06.nahpc.arm.com:7010@aphpc-lic03.ap01.arm.com:7010@euhpc-lic-armlmd.euhpc.arm.com
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Install ARM Compiler 6.6


### PR DESCRIPTION
Add more license server to fix that

https://jenkins-mbedtls.oss.arm.com/blue/organizations/jenkins/mbed-tls-pr-merge/detail/PR-5679-merge/33/pipeline/393 report arm license fail. 
And all build report same error now. 