### PR TITLE
Increase timeout for windows_testing.py

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -31,7 +31,12 @@ import groovy.transform.Field
  * Raas has its own resource queue with the timeout of 1000s, we need to take
  * it into account for the on-target test jobs.
  */
-@Field perJobTimeout = [time: 60, raasOffset: 17, unit: 'MINUTES']
+@Field perJobTimeout = [
+        time: 60,
+        raasOffset: 17,
+        windowsTestingOffset: 60,
+        unit: 'MINUTES'
+]
 
 @Field compiler_paths = [
     'gcc' : 'gcc',

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -298,7 +298,8 @@ def gen_windows_testing_job(build, label_prefix='') {
                  * written to a file so that it can be run on a node. */
                 def windows_testing = libraryResource 'windows/windows_testing.py'
                 writeFile file: 'windows_testing.py', text: windows_testing
-                timeout(time: common.perJobTimeout.time,
+                timeout(time: common.perJobTimeout.time +
+                              common.perJobTimeout.windowsTestingOffset,
                         unit: common.perJobTimeout.unit) {
                     bat "python windows_testing.py src logs -b $build"
                 }


### PR DESCRIPTION
OpenCI currently uses slightly slower executors for windows testing which pushes us up over the time limit set for windows tests. The tests take around 59 minutes on the internal CI and, around 70 minutes on the OpenCI.
The windows tests are not the bottleneck on the internal CI, so increasing the limit should not slow down testing at all.