### PR TITLE
Fix null pointer exception in error message parsing

### DIFF
--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -109,8 +109,8 @@ def run_pr_job(is_production=true) {
             }
         } catch (err) {
             def description = 'Pre Test Checks failed.'
-            if (err.getMessage().contains('Pre Test Checks')) {
-                description = err.getMessage()
+            if (err.message?.startsWith('Pre Test Checks')) {
+                description = err.message
             }
             common.maybe_notify_github "Pre Test Checks", 'FAILURE',
                                         description


### PR DESCRIPTION
The message of an Exception may be null.
This situation shows up in particular if a test run is cancelled due to a newer job for the same PR being launched.

Eg. https://ci.trustedfirmware.org/job/mbed-tls-pr-merge/job/PR-6436-merge/3/

Patched PR-HEAD run in the same scenario:
[Cancelled job](https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/3/)  
[Successor job](https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/4/)
[Failure of pre test checks](https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-919-head/1/)
