### PR TITLE
Driver-only hashes: test coverage in the CI

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -54,7 +54,8 @@ def gather_outcomes() {
                 }
                 try {
                     if (fileExists('tests/scripts/analyze_outcomes.py')) {
-                        sh 'tests/scripts/analyze_outcomes.py outcomes.csv'
+                        sh 'tests/scripts/analyze_outcomes.py outcomes.csv --task analyze_coverage'
+                        sh 'tests/scripts/analyze_outcomes.py outcomes.csv --task analyze_driver_vs_reference --components test_psa_crypto_config_accel_hash_use_psa,test_psa_crypto_config_reference_hash_use_psa --ignore md,mdx,shax,entropy,hmac_drbg,random,psa_crypto_init,hkdf'
                     }
                 } finally {
                     sh 'xz outcomes.csv'


### PR DESCRIPTION
Add CI test to verify if we have no regression in test coverage for driver-only-hashes build.

Resolves: https://github.com/Mbed-TLS/mbedtls/issues/6445
Related PR: https://github.com/Mbed-TLS/mbedtls/pull/6466 - this PR needs to be merged first.