### PR TITLE
Add stage declaration for Result analysis phase

### DIFF
--- a/vars/mbedtls-release-Jenkinsfile
+++ b/vars/mbedtls-release-Jenkinsfile
@@ -57,6 +57,8 @@ timestamps {
         }
     }
     finally {
-        analysis.analyze_results()
+        stage('result-analysis') {
+            analysis.analyze_results()
+        }
     }
 }

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -126,7 +126,9 @@ def run_pr_job(is_production=true) {
                 run_tls_tests()
             }
         } finally {
-            analysis.analyze_results_and_notify_github()
+            stage('result-analysis') {
+                analysis.analyze_results_and_notify_github()
+            }
         }
     }
 }


### PR DESCRIPTION
This makes the steps show up on the Blue Ocean view of the test runs.

Without this PR, failures in the Result analysis process would only show up in Github status reports, and the old Jenkins UI.

Eg. see [this comment](https://github.com/Mbed-TLS/mbedtls/issues/6466#issuecomment-1294474977) in Mbed-TLS/mbedtls#6466