### PR TITLE
Only consider pushes, manual CI runs and reviews as "PR activity" for the purposes of nightly builds

### DIFF
--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -103,8 +103,8 @@ def run_pr_job(is_production=true) {
             if (env.BRANCH_NAME ==~ /PR-\d+-merge/ &&
                 currentBuild.rawBuild.getCauses()[0].toString().contains('BranchIndexingCause'))
             {
-                upd_timestamp_ms = pullRequest.updatedAt.getTime()
-                now_timestamp_ms = currentBuild.startTimeInMillis
+                long upd_timestamp_ms = pullRequest.updatedAt.time
+                long now_timestamp_ms = currentBuild.startTimeInMillis
                 /* current threshold is 2 days */
                 long threshold_ms = 2L * 24L * 60L * 60L * 1000L
                 if (now_timestamp_ms - upd_timestamp_ms > threshold_ms) {

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -17,7 +17,11 @@
  *  This file is part of Mbed TLS (https://www.trustedfirmware.org/projects/mbed-tls/)
  */
 
+import hudson.model.Item
 import jenkins.branch.BranchIndexingCause
+import jenkins.scm.api.SCMSource
+import org.jenkinsci.plugins.github_branch_source.Connector
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource
 
 Map wrap_report_errors(Map jobs) {
     return jobs.collectEntries { name, job ->
@@ -107,12 +111,32 @@ def run_pr_job(is_production=true) {
                 long now_timestamp_ms = currentBuild.startTimeInMillis
                 try {
                     if (currentBuild.rawBuild.causes[0] instanceof BranchIndexingCause) {
-                        /* Try to retrieve the update timestamp from the previous run.
-                         * Fall back on updatedAt if the environment variable is missing
-                         */
-                        upd_timestamp_ms = (currentBuild.previousBuild?.buildVariables?.UPD_TIMESTAMP_MS ?: pullRequest.updatedAt.time) as long
+                        /* Try to retrieve the update timestamp from the previous run. */
+                        upd_timestamp_ms = (currentBuild.previousBuild?.buildVariables?.UPD_TIMESTAMP_MS ?: 0L) as long
                         /* current threshold is 2 days */
                         long threshold_ms = 2L * 24L * 60L * 60L * 1000L
+
+                        if (now_timestamp_ms - upd_timestamp_ms > threshold_ms) {
+                            /* Check the time of the latest review */
+                            def src = (GitHubSCMSource) SCMSource.SourceByItem.findSource(currentBuild.rawBuild.parent)
+                            def cred = Connector.lookupScanCredentials((Item) src.owner, src.apiUri, src.credentialsId)
+
+                            def gh = Connector.connect(src.apiUri, cred)
+                            def pr = gh.getRepository("$src.repoOwner/$src.repository").getPullRequest(env.CHANGE_ID as int)
+
+                            try {
+                                long review_timestamp_ms = pr.listReviews().last().submittedAt.time
+                                upd_timestamp_ms = Math.max(review_timestamp_ms, upd_timestamp_ms)
+                            } catch (NoSuchElementException err) {
+                                /* No reviews */
+                            }
+
+                            if (upd_timestamp_ms == 0L) {
+                                /* Fall back to updatedAt */
+                                upd_timestamp_ms = pr.updatedAt.time
+                            }
+                        }
+
                         if (now_timestamp_ms - upd_timestamp_ms > threshold_ms) {
                             currentBuild.result = 'NOT_BUILT'
                             error("Pre Test Checks did not run: PR was last updated on ${new Date(upd_timestamp_ms)}.")

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -113,6 +113,8 @@ def run_pr_job(is_production=true) {
                     if (currentBuild.rawBuild.causes[0] instanceof BranchIndexingCause) {
                         /* Try to retrieve the update timestamp from the previous run. */
                         upd_timestamp_ms = (currentBuild.previousBuild?.buildVariables?.UPD_TIMESTAMP_MS ?: 0L) as long
+                        echo "Previous update timestamp: ${new Date(upd_timestamp_ms)}"
+
                         /* current threshold is 2 days */
                         long threshold_ms = 2L * 24L * 60L * 60L * 1000L
 
@@ -126,6 +128,7 @@ def run_pr_job(is_production=true) {
 
                             try {
                                 long review_timestamp_ms = pr.listReviews().last().submittedAt.time
+                                echo "Latest review timestamp: ${new Date(review_timestamp_ms)}"
                                 upd_timestamp_ms = Math.max(review_timestamp_ms, upd_timestamp_ms)
                             } catch (NoSuchElementException err) {
                                 /* No reviews */
@@ -134,6 +137,7 @@ def run_pr_job(is_production=true) {
                             if (upd_timestamp_ms == 0L) {
                                 /* Fall back to updatedAt */
                                 upd_timestamp_ms = pr.updatedAt.time
+                                echo "UpdateAt timestamp: ${new Date(upd_timestamp_ms)}"
                             }
                         }
 

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -137,7 +137,7 @@ def run_pr_job(is_production=true) {
                             if (upd_timestamp_ms == 0L) {
                                 /* Fall back to updatedAt */
                                 upd_timestamp_ms = pr.updatedAt.time
-                                echo "UpdateAt timestamp: ${new Date(upd_timestamp_ms)}"
+                                echo "PR updatedAt timestamp: ${new Date(upd_timestamp_ms)}"
                             }
                         }
 
@@ -152,6 +152,7 @@ def run_pr_job(is_production=true) {
                 } finally {
                     /* Record the update timestamp in the environment, so it can be retrieved by the next run */
                     env.UPD_TIMESTAMP_MS = upd_timestamp_ms
+                    echo "UPD_TIMESTAMP_MS=$env.UPD_TIMESTAMP_MS (${new Date(upd_timestamp_ms)})"
                 }
             }
 

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -17,6 +17,8 @@
  *  This file is part of Mbed TLS (https://www.trustedfirmware.org/projects/mbed-tls/)
  */
 
+import jenkins.branch.BranchIndexingCause
+
 Map wrap_report_errors(Map jobs) {
     return jobs.collectEntries { name, job ->
         [(name): {
@@ -101,7 +103,7 @@ def run_pr_job(is_production=true) {
             * job for that PR.
             */
             if (env.BRANCH_NAME ==~ /PR-\d+-merge/ &&
-                currentBuild.rawBuild.getCauses()[0].toString().contains('BranchIndexingCause'))
+                currentBuild.rawBuild.causes[0] instanceof BranchIndexingCause)
             {
                 long upd_timestamp_ms = pullRequest.updatedAt.time
                 long now_timestamp_ms = currentBuild.startTimeInMillis


### PR DESCRIPTION
This PR restricts what we consider as PR activity for the purposes of nightly merge builds to the following:
1. Manual pushes of the PR branch
2. Manual CI runs on the PR
3. Reviews of the PR

Since Github doesn't track when the PR was last pushed in a convenient way, we record the "last update timestamp" in our environment, which can be retrieved by subsequent CI runs, and update this timestamp if the CI is triggered by anything other than the nightly repo scan.

If none of the above timestamps are available (eg. in the initial CI run on a PR after this is merged, where there are no previous reviews), we fall back to the `updated_at` property that we have been using so far - this metric includes things like comments, label changes, etc.