### PR TITLE
Upload a failure list as a Jenkins artifact

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -32,6 +32,27 @@ def stash_outcomes(job_name) {
     }
 }
 
+// In a directory with the source tree available, process the outcome files
+// from all the jobs.
+def process_outcomes() {
+    dir('csvs') {
+        for (stash_name in outcome_stashes) {
+            unstash(stash_name)
+        }
+        sh 'cat *.csv >../outcomes.csv'
+        deleteDir()
+    }
+    try {
+        if (fileExists('tests/scripts/analyze_outcomes.py')) {
+            sh 'tests/scripts/analyze_outcomes.py outcomes.csv'
+        }
+    } finally {
+        sh 'xz outcomes.csv'
+        archiveArtifacts(artifacts: 'outcomes.csv.xz',
+        fingerprint: true, allowEmptyArchive: true)
+    }
+}
+
 def gather_outcomes() {
     // After running on an old branch which doesn't have the outcome
     // file generation mechanism, or after running a partial run,
@@ -45,22 +66,7 @@ def gather_outcomes() {
             deleteDir()
             try {
                 checkout_repo.checkout_repo()
-                dir('csvs') {
-                    for (stash_name in outcome_stashes) {
-                        unstash(stash_name)
-                    }
-                    sh 'cat *.csv >../outcomes.csv'
-                    deleteDir()
-                }
-                try {
-                    if (fileExists('tests/scripts/analyze_outcomes.py')) {
-                        sh 'tests/scripts/analyze_outcomes.py outcomes.csv'
-                    }
-                } finally {
-                    sh 'xz outcomes.csv'
-                    archiveArtifacts(artifacts: 'outcomes.csv.xz',
-                    fingerprint: true, allowEmptyArchive: true)
-                }
+                process_outcomes()
             } finally {
                 deleteDir()
             }

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -19,8 +19,9 @@
 
 import groovy.transform.Field
 
-// Keep track of builds that fail
-@Field failed_builds = [:]
+// Keep track of builds that fail.
+// Use static field, so the is content preserved across stages.
+@Field static failed_builds = [:]
 
 //Record coverage details for reporting
 @Field coverage_details = ['coverage': 'Code coverage job did not run']


### PR DESCRIPTION
When a job fails, provide an artifact `failures.csv` (or `failures.csv.xz` if it's large) containing just the failed test cases from the `outcomes.csv`. The complete outcome file is very large but the list of failed test cases is typically a lot smaller, so this makes it easier to download and analyze the failures and only wastes a very small amount of space on the server.

CI runs on https://github.com/Mbed-TLS/mbedtls-test/pull/72/commits/c86f7ebb5d71f420569ca091c8b115575575661f:

* [Passing](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/420/), expecting no `failures.csv` → OK
* [Build failures but no failing test case](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/419/), expecting empty `failures.csv` → OK
* [Failed a few test cases](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/418/) (from [ECP read](https://github.com/Mbed-TLS/mbedtls/pull/6282#issuecomment-1257924304)), expecting `failures.csv` with failures → OK
* I haven't run a test that triggers the branch to compress `failures.csv`, but [an earlier run with some leftover artifacts from testing (looking for SKIP instead of FAIL)](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/415/) did.
