### PR TITLE
Add Uncrustify to the docker images (and other improvements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ When raising a PR in [mbedtls](https://github.com/ARMmbed/mbedtls) a range of te
 
 The docker files in `resources/docker_files` are the ones used by the CI. For more information see the corresponding readme: `resources/docker_files/README.md`.
 
+## Quick Start
+
+To get the docker image used in the CI, run the following command from the root of a fresh checkout of the `master` branch of this repository:
+```sh
+docker pull trustedfirmware/ci-amd64-mbed-tls-ubuntu:ubuntu-16.04-$(git hash-object resources/docker_files/ubuntu-16.04/Dockerfile)
+```
+Then to run the image:
+```sh
+./resources/docker_files/run.sh <mount dir> trustedfirmware/ci-amd64-mbed-tls-ubuntu:ubuntu-16.04-$(git hash-object resources/docker_files/ubuntu-16.04/Dockerfile)
+```
+Where `<mount dir>` is a directory from the host that will be mounted on the container at startup (usually a local checkout of Mbed TLS).
+
+If `<mount dir>` is the root of an Mbed TLS source tree, the tests can be run with:
+```sh
+./tests/scripts/all.sh --no-armcc
+```
+
 ## Contribution
 
 This repository accepts contributions only from Mbed TLS maintainers.

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -114,7 +114,7 @@ RUN apt-get update -q && apt-get install -yq \
     && rm -rf /var/lib/apt/lists/
 
 # Install ARM Compiler 5.06
-RUN wget -q https://developer.arm.com/-/media/Files/downloads/compiler/DS500-PA-00003-r5p0-22rel0.tgz && \
+RUN wget -q https://armkeil.blob.core.windows.net/developer/Files/downloads/compiler/DS500-PA-00003-r5p0-22rel0.tgz && \
     tar -zxf DS500-PA-00003-r5p0-22rel0.tgz && \
     ./Installer/setup.sh --i-agree-to-the-contained-eula --no-interactive -d /usr/local/ARM_Compiler_5.06u3 --quiet && \
     rm -rf DS500-PA-00003-r5p0-22rel0.tgz releasenotes.html Installer/
@@ -126,7 +126,7 @@ ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Install ARM Compiler 6.6
 RUN mkdir temp && cd temp && \
-    wget -q --no-check-certificate https://developer.arm.com/-/media/Files/downloads/compiler/DS500-BN-00026-r5p0-07rel0.tgz?revision=8f0d9fb0-9616-458c-b2f5-d0dac83ea93c?product=Downloads,64-bit,,Linux,6.6 -O arm6.tgz && \
+    wget -q --no-check-certificate https://armkeil.blob.core.windows.net/developer//sitecore/shell/-/media/Files/downloads/compiler/DS500-BN-00026-r5p0-07rel0.tgz -O arm6.tgz && \
     tar -zxf arm6.tgz  && ls -ltr && \
     ./install_x86_64.sh --i-agree-to-the-contained-eula --no-interactive -d /usr/local/ARM_Compiler_6.6 --quiet && \
     cd .. && rm -rf temp/

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -121,7 +121,7 @@ RUN wget -q https://github.com/lvc/abi-compliance-checker/archive/2.3.tar.gz && 
     rm -rf abi-compliance-checker* && rm 2.3.tar.gz
 
 # Install ARM Compiler 5.06
-RUN wget -q https://developer.arm.com/-/media/Files/downloads/compiler/DS500-PA-00003-r5p0-22rel0.tgz && \
+RUN wget -q https://armkeil.blob.core.windows.net/developer/Files/downloads/compiler/DS500-PA-00003-r5p0-22rel0.tgz && \
     tar -zxf DS500-PA-00003-r5p0-22rel0.tgz && \
     ./Installer/setup.sh --i-agree-to-the-contained-eula --no-interactive -d /usr/local/ARM_Compiler_5.06u3 --quiet && \
     rm -rf DS500-PA-00003-r5p0-22rel0.tgz releasenotes.html Installer/
@@ -133,7 +133,7 @@ ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Install ARM Compiler 6.6
 RUN mkdir temp && cd temp && \
-    wget -q --no-check-certificate https://developer.arm.com/-/media/Files/downloads/compiler/DS500-BN-00026-r5p0-07rel0.tgz?revision=8f0d9fb0-9616-458c-b2f5-d0dac83ea93c?product=Downloads,64-bit,,Linux,6.6 -O arm6.tgz && \
+    wget -q --no-check-certificate https://armkeil.blob.core.windows.net/developer//sitecore/shell/-/media/Files/downloads/compiler/DS500-BN-00026-r5p0-07rel0.tgz -O arm6.tgz && \
     tar -zxf arm6.tgz  && ls -ltr && \
     ./install_x86_64.sh --i-agree-to-the-contained-eula --no-interactive -d /usr/local/ARM_Compiler_6.6 --quiet && \
     cd .. && rm -rf temp/

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -236,6 +236,12 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 
+# Install uncrustify
+# We need version 0.75.1
+RUN git clone --branch uncrustify-0.75.1 https://github.com/uncrustify/uncrustify.git && \
+    cd uncrustify && mkdir build && cd build && cmake .. && make install && \
+    cd .. && rm -rf uncrustify
+
 # Install Python pip packages
 #
 # The pip wrapper scripts can get out of sync with pip due to upgrading it

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -235,6 +235,12 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 
+# Install uncrustify
+# We need version 0.75.1
+RUN git clone --branch uncrustify-0.75.1 https://github.com/uncrustify/uncrustify.git && \
+    cd uncrustify && mkdir build && cd build && cmake .. && make install && \
+    cd .. && rm -rf uncrustify
+
 # Install Python pip packages
 #
 # The pip wrapper scripts can get out of sync with pip due to upgrading it

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -120,7 +120,7 @@ RUN apt-get update -q && apt-get install -yq \
     && rm -rf /var/lib/apt/lists/
 
 # Install ARM Compiler 5.06
-RUN wget -q https://developer.arm.com/-/media/Files/downloads/compiler/DS500-PA-00003-r5p0-22rel0.tgz && \
+RUN wget -q https://armkeil.blob.core.windows.net/developer/Files/downloads/compiler/DS500-PA-00003-r5p0-22rel0.tgz && \
     tar -zxf DS500-PA-00003-r5p0-22rel0.tgz && \
     ./Installer/setup.sh --i-agree-to-the-contained-eula --no-interactive -d /usr/local/ARM_Compiler_5.06u3 --quiet && \
     rm -rf DS500-PA-00003-r5p0-22rel0.tgz releasenotes.html Installer/
@@ -132,7 +132,7 @@ ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Install ARM Compiler 6.6
 RUN mkdir temp && cd temp && \
-    wget -q --no-check-certificate https://developer.arm.com/-/media/Files/downloads/compiler/DS500-BN-00026-r5p0-07rel0.tgz?revision=8f0d9fb0-9616-458c-b2f5-d0dac83ea93c?product=Downloads,64-bit,,Linux,6.6 -O arm6.tgz && \
+    wget -q --no-check-certificate https://armkeil.blob.core.windows.net/developer//sitecore/shell/-/media/Files/downloads/compiler/DS500-BN-00026-r5p0-07rel0.tgz -O arm6.tgz && \
     tar -zxf arm6.tgz  && ls -ltr && \
     ./install_x86_64.sh --i-agree-to-the-contained-eula --no-interactive -d /usr/local/ARM_Compiler_6.6 --quiet && \
     cd .. && rm -rf temp/


### PR DESCRIPTION
This PR does the following 3 things:
* Update download links for Arm Compiler in the Dockerfiles.
* Add Uncrustify to the 18.04 and 20.04 docker images.
* Document quick-start instructions for getting the current docker image (without having to build it) and running tests.