### PR TITLE
Fix dispatch to Ubuntu 20.04

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -51,10 +51,6 @@ import groovy.transform.Field
 
 @Field linux_platforms = ["ubuntu-16.04", "ubuntu-18.04", "ubuntu-20.04"]
 @Field bsd_platforms = ["freebsd"]
-@Field bsd_compilers = ["clang"]
-@Field all_compilers = ['gcc', 'clang']
-@Field gcc_compilers = ['gcc']
-@Field asan_compilers = ['clang']
 
 @Field available_all_sh_components = [:]
 @Field all_all_sh_components = []

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -607,13 +607,9 @@ def gen_release_jobs(label_prefix='', run_examples=true) {
     }
 
     if (env.RUN_ALL_SH == "true") {
-        for (component in common.available_all_sh_components['ubuntu-16.04']) {
-            jobs = jobs + gen_all_sh_jobs('ubuntu-16.04', component, label_prefix)
-        }
-        for (component in (common.available_all_sh_components['ubuntu-18.04'] -
-                           common.available_all_sh_components['ubuntu-16.04'])) {
-            jobs = jobs + gen_all_sh_jobs('ubuntu-18.04', component, label_prefix)
-        }
+        common.all_all_sh_components.each({component, platform ->
+            jobs = jobs + gen_all_sh_jobs(platform, component, label_prefix)
+        })
     }
 
     /* FreeBSD all.sh jobs */


### PR DESCRIPTION
If an `all.sh` component is supported only on Ubuntu 20.04, and not on 18.04 or 16.04, it is silently skipped. Fix this.

Test runs:

* [Branch that has a 20.04-only job](https://github.com/gilles-peskine-arm/mbedtls/tree/all.sh-modern-ubsan): https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/428/ → OK (pass, 20.04 job ran as expected)
* development: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/430/ → OK
