### PR TITLE
Increase timeout for all.sh jobs to 120 minutes

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -34,9 +34,9 @@ import hudson.AbortException
  * it into account for the on-target test jobs.
  */
 @Field perJobTimeout = [
-        time: 60,
+        time: 120,
         raasOffset: 17,
-        windowsTestingOffset: 60,
+        windowsTestingOffset: 0,
         unit: 'MINUTES'
 ]
 


### PR DESCRIPTION
This matches the previous timeout for Windows jobs.

Signed-off-by: Bence Szépkúti <bence.szepkuti@arm.com>