### PR TITLE
Make the CI Docker images more discoverable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ If `<mount dir>` is the root of an Mbed TLS source tree, the tests can be run wi
 ./tests/scripts/all.sh --no-armcc
 ```
 
+For more details on the docker images, see [their dedicated Readme](resources/docker_files/README.md).
+
 ## Contribution
 
 This repository accepts contributions only from Mbed TLS maintainers.

--- a/resources/docker_files/README.md
+++ b/resources/docker_files/README.md
@@ -4,9 +4,30 @@ Docker files for some of the supported platforms are provided here. These are pr
 
 These images have proved very useful in replicating CI build environment and reproducing build & test failures. Hence, very useful for developers fixing issues found in the CI.
 
-## Development interface
+## Using the images
 
-Docker is started with an interactive shell to emulate a development environment. Helper script ```run.sh``` can be used to launch a docker image:
+
+Remember to build the docker image before running ```run.sh```.
+
+## Getting pre-built images from the CI
+
+See the [Quick Start section of the top-level README](../../README.md#quick-start) in this repository.
+
+## Re-builing images locally
+
+A docker image can be built with following command:
+```sh
+cd mbedtls-test/dev_envs/docker_files
+sudo docker build --network=host -t ubuntu-18.04 -f ubuntu-18.04/Dockerfile .
+```
+This creates an image from the specified file. The built image is maintained by docker in it's own workspace on the host. Don't worry where the built image is gone! From this point the built image is referred by it's tag name. For example ```ubuntu-18.04```. See [Listing images](#listing-images) below.
+
+Note: `--network=host` may or may not necessary depending on your machine's
+configuration, including whether you're using a VPN or not.
+
+## Running the images using the helper script
+
+The helper script ```run.sh``` can be used to launch a docker image:
 ```sh
 ./run.sh <mount dir> <image tag>
 ```
@@ -15,58 +36,17 @@ Docker is started with an interactive shell to emulate a development environment
 - mounts ```~/.ssh``` directory to the docker home so that ```git``` can be used from within the docker.
 - configures user ids for the docker user to be same as the host user to preserve the permissions on the files created or modified inside the docker.
 
-Remember to build the docker image before running ```run.sh```.
+## Running the images manually
 
-## Docker setup
-* **build** - 
-A docker image can be built with following command:
-```sh
-cd mbedtls-test/dev_envs/docker_files
-sudo docker build --network=host -t ubuntu-18.04 -f ubuntu-18.04/Dockerfile .
-```
-This creates an image from the specified file. Built image is maintained by docker in it's own workspace on the host. Don't worry where the built image is gone! From this point the built image is referred by it's tag name. For example ```ubuntu-18.04```.
-
-Note: `--network=host` may or may not necessary depending on your machine's
-configuration, including whether you're using a VPN or not.
-
-* **run** -
-Following basic command starts docker in an interactive mode:
+The following basic command starts docker in an interactive mode:
 ```sh
 sudo docker run --network=host --rm -i -t ubuntu-18.04
 ```
 Above, ```-i``` is for interactive mode and ```-t``` is for emulating a tty. ```--rm``` tells docker to cleanup the container after exit. (See note above regarding `--network=host`.) All images launch ```bash``` on startup. Hence, user is on a ```bash``` shell when image is started in the interactive mode.
 
-Use ```run.sh``` for enabling ```git``` and mounting a host workspace inside docker. Example:
-```sh
-$ ./run.sh /home/mazimkhan/github/mazimkhan ubuntu-18.04
-****************************************************
-  Running docker image ubuntu-18.04
-  User ID:Group ID --> 1000:1000
-  Mounting /home/mazimkhan/.ssh --> /home/user/.ssh
-  Mounting /home/mazimkhan/github/mazimkhan --> /var/lib/ws
-****************************************************
-ls
-charontls
-mbed-os
-mbed-os-example-tls
-mbed-os-example-tls_armmbed
-mbedtls
-mbedtls-restricted
-mbedtls-test
-nRF5_SDK_14.0.0_3bcc1f7
-nrf52_dk_example
-systest-jenkins-dockerfiles
+## Listing images
 
-exit
-```
-
-* **listing images**
 Built images on host machine can be viewed using command:
 ```sh
-$ sudo docker images
-[sudo] password for mazimkhan: 
-REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
-ubuntu-18.04           latest              d62631abe664        2 hours ago         2.39GB
-ubuntu-16.04           latest              f25e332cb5d8        5 weeks ago         4.04GB
-ubuntu                 16.04               747cb2d60bbe        7 weeks ago         122MB
+sudo docker images
 ```

--- a/resources/docker_files/README.md
+++ b/resources/docker_files/README.md
@@ -1,6 +1,6 @@
 # Mbed TLS development Environment on docker
 
-Docker files for some of the supported platforms are provided here. These are prepared with all necessary tools for building and testing Mbed TLS library and its sample applications (as tested in the CI). These images can also be seen as a reference for building a development enviroment for Mbed TLS.
+Docker files for some of the supported platforms are provided here. These are prepared with all necessary tools for building and testing Mbed TLS library and its sample applications (as tested in the CI). These images can also be seen as a reference for building a development environment for Mbed TLS.
 
 These images have proved very useful in replicating CI build environment and reproducing build & test failures. Hence, very useful for developers fixing issues found in the CI.
 

--- a/resources/docker_files/README.md
+++ b/resources/docker_files/README.md
@@ -1,6 +1,6 @@
 # Mbed TLS development Environment on docker
 
-Docker files for some of the supported platforms are provided here. These are prepared with all necessary tools for building and testing Mbed TLS library and it's sample applications (as tested in the CI). These images can also be seen as a reference for building a development enviroment for Mbed TLS.
+Docker files for some of the supported platforms are provided here. These are prepared with all necessary tools for building and testing Mbed TLS library and its sample applications (as tested in the CI). These images can also be seen as a reference for building a development enviroment for Mbed TLS.
 
 These images have proved very useful in replicating CI build environment and reproducing build & test failures. Hence, very useful for developers fixing issues found in the CI.
 
@@ -20,7 +20,7 @@ A docker image can be built with following command:
 cd mbedtls-test/dev_envs/docker_files
 sudo docker build --network=host -t ubuntu-18.04 -f ubuntu-18.04/Dockerfile .
 ```
-This creates an image from the specified file. The built image is maintained by docker in it's own workspace on the host. Don't worry where the built image is gone! From this point the built image is referred by it's tag name. For example ```ubuntu-18.04```. See [Listing images](#listing-images) below.
+This creates an image from the specified file. The built image is maintained by docker in its own workspace on the host. Don't worry where the built image is gone! From this point the built image is referred by its tag name. For example ```ubuntu-18.04```. See [Listing images](#listing-images) below.
 
 Note: `--network=host` may or may not be necessary depending on your machine's
 configuration, including whether you're using a VPN or not.

--- a/resources/docker_files/README.md
+++ b/resources/docker_files/README.md
@@ -13,7 +13,7 @@ Remember to build the docker image before running ```run.sh```.
 
 See the [Quick Start section of the top-level README](../../README.md#quick-start) in this repository.
 
-## Re-builing images locally
+## Re-building images locally
 
 A docker image can be built with following command:
 ```sh
@@ -22,7 +22,7 @@ sudo docker build --network=host -t ubuntu-18.04 -f ubuntu-18.04/Dockerfile .
 ```
 This creates an image from the specified file. The built image is maintained by docker in it's own workspace on the host. Don't worry where the built image is gone! From this point the built image is referred by it's tag name. For example ```ubuntu-18.04```. See [Listing images](#listing-images) below.
 
-Note: `--network=host` may or may not necessary depending on your machine's
+Note: `--network=host` may or may not be necessary depending on your machine's
 configuration, including whether you're using a VPN or not.
 
 ## Running the images using the helper script
@@ -31,7 +31,7 @@ The helper script ```run.sh``` can be used to launch a docker image:
 ```sh
 ./run.sh <mount dir> <image tag>
 ```
-```run.sh``` makes it easier to start images with a suitable working environment. It
+```run.sh``` makes it easier to start images with a suitable working environment. It:
 - mounts a local directory on to the container at startup. Hence, a local checkout of Mbed TLS can be used and artefacts produced can be preserved even after exiting the image.
 - mounts ```~/.ssh``` directory to the docker home so that ```git``` can be used from within the docker.
 - configures user ids for the docker user to be same as the host user to preserve the permissions on the files created or modified inside the docker.
@@ -46,7 +46,7 @@ Above, ```-i``` is for interactive mode and ```-t``` is for emulating a tty. ```
 
 ## Listing images
 
-Built images on host machine can be viewed using command:
+Built images on host machine can be viewed using the command:
 ```sh
 sudo docker images
 ```

--- a/resources/docker_files/README.md
+++ b/resources/docker_files/README.md
@@ -7,7 +7,7 @@ These images have proved very useful in replicating CI build environment and rep
 ## Using the images
 
 
-Remember to build the docker image before running ```run.sh```.
+Remember to build the docker image before running `run.sh`.
 
 ## Getting pre-built images from the CI
 
@@ -20,20 +20,20 @@ A docker image can be built with following command:
 cd mbedtls-test/dev_envs/docker_files
 sudo docker build --network=host -t ubuntu-18.04 -f ubuntu-18.04/Dockerfile .
 ```
-This creates an image from the specified file. The built image is maintained by docker in its own workspace on the host. Don't worry where the built image is gone! From this point the built image is referred by its tag name. For example ```ubuntu-18.04```. See [Listing images](#listing-images) below.
+This creates an image from the specified file. The built image is maintained by docker in its own workspace on the host. Don't worry where the built image is gone! From this point the built image is referred by its tag name. For example `ubuntu-18.04`. See [Listing images](#listing-images) below.
 
 Note: `--network=host` may or may not be necessary depending on your machine's
 configuration, including whether you're using a VPN or not.
 
 ## Running the images using the helper script
 
-The helper script ```run.sh``` can be used to launch a docker image:
+The helper script `run.sh` can be used to launch a docker image:
 ```sh
 ./run.sh <mount dir> <image tag>
 ```
-```run.sh``` makes it easier to start images with a suitable working environment. It:
+`run.sh` makes it easier to start images with a suitable working environment. It:
 - mounts a local directory on to the container at startup. Hence, a local checkout of Mbed TLS can be used and artefacts produced can be preserved even after exiting the image.
-- mounts ```~/.ssh``` directory to the docker home so that ```git``` can be used from within the docker.
+- mounts `~/.ssh` directory to the docker home so that `git` can be used from within the docker.
 - configures user ids for the docker user to be same as the host user to preserve the permissions on the files created or modified inside the docker.
 
 ## Running the images manually
@@ -42,7 +42,7 @@ The following basic command starts docker in an interactive mode:
 ```sh
 sudo docker run --network=host --rm -i -t ubuntu-18.04
 ```
-Above, ```-i``` is for interactive mode and ```-t``` is for emulating a tty. ```--rm``` tells docker to cleanup the container after exit. (See note above regarding `--network=host`.) All images launch ```bash``` on startup. Hence, user is on a ```bash``` shell when image is started in the interactive mode.
+Above, `-i` is for interactive mode and `-t` is for emulating a tty. `--rm` tells docker to cleanup the container after exit. (See note above regarding `--network=host`.) All images launch `bash` on startup. Hence, user is on a `bash` shell when image is started in the interactive mode.
 
 ## Listing images
 


### PR DESCRIPTION
Trying to make it more discoverable how to fetch images used by the CI.

See also https://github.com/Mbed-TLS/mbedtls/pull/6789