### PR TITLE
Fix release job

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -330,7 +330,7 @@ Logs: ${env.BUILD_URL}
 }
 
 def run_release_jobs(name, jobs, failed_builds, coverage_details) {
-    def jobs_wrapped = common.wrap_report_errors(jobs)
+    def jobs_wrapped = wrap_report_errors(jobs)
     jobs_wrapped.failFast = false
     try {
         parallel jobs_wrapped


### PR DESCRIPTION
"common" inside common.groovy refers to the groovy class - not the singleton instance.

Pre-patch tests:
[Internal][1] [OpenCI][2]
Post-patch tests:
[Internal][3] [OpenCI][4]

[1]:https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/432/
[2]:https://ci.staging.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-release-ci-testing/1/
[3]:https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/433/
[4]:https://ci.staging.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-release-ci-testing/2/