### PR TITLE
Fix error reporting

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -121,7 +121,7 @@ Caught: $writer
 """
                 if (!currentBuild.resultIsWorseOrEqualTo('FAILURE')) {
                     currentBuild.result = 'FAILURE'
-                    common.maybe_notify_github 'TLS Testing', 'FAILURE',
+                    maybe_notify_github 'TLS Testing', 'FAILURE',
                             "Failures: ${name}…"
                 }
                 throw err


### PR DESCRIPTION
Missed reference to "common" when refactoring wrap_report_errors().

Same issue as in #92, just on the error path.

Pre-path tests:
[Internal][1] [OpenCI][2]
Post-patch tests:
[Internal][3] [OpenCI][4]

[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/job/PR-759-head/7/
[2]: https://ci.staging.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/job/PR-759-head/1/
[3]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/job/PR-759-head/9/
[4]: https://ci.staging.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/job/PR-759-head/2/