### PR TITLE
Add gather timestamps job

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -152,6 +152,7 @@ static List<JSONObject> gather_timestamps_since(ItemGroup project_root, long thr
                         if (pr) {
                             json.pr = pr as Integer
                         }
+                        json.result = build.result.toString()
                         ((JSONObject) json.subtasks).main = json.remove('main')
                         json.version = 1
                     }
@@ -166,7 +167,7 @@ static List<JSONObject> gather_timestamps_since(ItemGroup project_root, long thr
 void gather_timestamps() {
     stage('gather-timestamps') {
         def builds = gather_timestamps_since(currentBuild.rawBuild.parent.parent, currentBuild.startTimeInMillis - 24 * 60 * 60 * 1000)
-        def group_path = ['testCommit': null, 'job': null, 'branch': null, 'pr': -1, 'build': -1]
+        def group_path = ['testCommit': null, 'job': null, 'branch': null, 'pr': -1, 'build': -1, 'result': null]
         def ts_format = ['start', 'end', 'innerStart', 'innerEnd']
 
         List<String> records = [(group_path.keySet() + ['group', 'subtask'] + ts_format).join(',')]

--- a/vars/mbedtls-gather-timestamps-Jenkinsfile
+++ b/vars/mbedtls-gather-timestamps-Jenkinsfile
@@ -1,0 +1,24 @@
+#!/usr/bin/env groovy
+
+/*
+ *  Copyright (c) 2018-2023, Arm Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://www.trustedfirmware.org/projects/mbed-tls/)
+ */
+
+/* main job */
+library identifier: 'mbedtls-test@master', retriever: legacySCM(scm)
+analysis.gather_timestamps()


### PR DESCRIPTION
Introduce a job which collects the timestamps produced by the PR and nightly release jobs in the past 24 hours, and produces CSV and JSON files for easy consumption of this data.

In the process, it upgrades version 0 JSON timestamps (the current format) to include all the additional data included in the CSV file. I will file a separate PR to move us to this format when gathering timestamps in the first place.

Test run:
Internal CI: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-gather-timestamps/56/

Question for reviewers / users. Would it be helpful to be able to configure the timespan to gather timestamps from?

The current idea is to run this job automatically every night, so we can preserve the timestamps of various jobs for a while longer after they are pruned due to eg. closed PRs. It also makes grabbing all of the timestamps of PR jobs at once a whole lot easier.