### PR TITLE
Improve timestamp gathering in release and pr jobs

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -23,8 +23,6 @@ import groovy.transform.Field
 
 import com.cloudbees.groovy.cps.NonCPS
 import hudson.AbortException
-import hudson.triggers.TimerTrigger
-import org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTriggerCause
 
 /* Indicates if CI is running on Open CI (hosted on https://ci.trustedfirmware.org/) */
 @Field is_open_ci_env = env.JENKINS_URL ==~ /\S+(trustedfirmware)\S+/
@@ -348,17 +346,4 @@ Logs: ${env.BUILD_URL}
              subject: subject,
              to: recipients,
              mimeType: 'text/plain'
-}
-
-def run_release_jobs(name, jobs, failed_builds, coverage_details) {
-    def jobs_wrapped = wrap_report_errors(jobs)
-    jobs_wrapped.failFast = false
-    try {
-        parallel jobs_wrapped
-    } finally {
-        if (currentBuild.rawBuild.causes[0] instanceof ParameterizedTimerTriggerCause ||
-            currentBuild.rawBuild.causes[0] instanceof TimerTrigger.TimerTriggerCause) {
-            send_email(name, env.MBED_TLS_BRANCH, failed_builds, coverage_details)
-        }
-    }
 }

--- a/vars/mbedtls-release-Jenkinsfile
+++ b/vars/mbedtls-release-Jenkinsfile
@@ -41,26 +41,4 @@
 
 /* main job */
 library identifier: 'mbedtls-test@master', retriever: legacySCM(scm)
-environ.set_tls_release_environment()
-
-timestamps {
-    try {
-        analysis.record_timestamps('main', 'release_jobs') {
-            common.init_docker_images()
-            stage('tls-testing') {
-                def jobs = gen_jobs.gen_release_jobs()
-                common.run_release_jobs(
-                        "Mbed TLS nightly tests",
-                        jobs,
-                        gen_jobs.failed_builds,
-                        gen_jobs.coverage_details
-                )
-            }
-        }
-    }
-    finally {
-        stage('result-analysis') {
-            analysis.analyze_results()
-        }
-    }
-}
+mbedtls.run_release_job()

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -190,17 +190,18 @@ def run_job() {
 }
 
 void run_release_job() {
-    environ.set_tls_release_environment()
-
     timestamps {
         try {
-            analysis.record_timestamps('main', 'release_jobs') {
+            analysis.record_timestamps('main', 'run_release_job') {
+                environ.set_tls_release_environment()
                 common.init_docker_images()
                 stage('tls-testing') {
                     def jobs = common.wrap_report_errors(gen_jobs.gen_release_jobs())
                     jobs.failFast = false
                     try {
-                        parallel jobs
+                        analysis.record_inner_timestamps('main', 'run_release_job') {
+                            parallel jobs
+                        }
                     } finally {
                         if (currentBuild.rawBuild.causes[0] instanceof ParameterizedTimerTriggerCause ||
                             currentBuild.rawBuild.causes[0] instanceof TimerTrigger.TimerTriggerCause) {


### PR DESCRIPTION
This PR improves the timestamp gathering in the release jobs by adding inner timestamps to the main job, bringing it up to parity with the PR jobs.

It also improves the timestamping of both kinds of jobs by recording timestamps for the analysis stage, breaking out the timestamp write-out process into a separate stage in the process.

Test runs:
Internal CI:
[Release test (good, development)][1]
[Release test (fail CMake)][2]
[PR test (good)][3]
[PR test (fail CMake)][4]

OpenCI:
[Release test (good, development)][5]
[Release test (fail CMake)][6]
[PR test (good)][7]
[PR test (fail CMake)][8]

[1]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/453/
[2]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/454/
[3]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-head/43/
[4]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-759-head/13/
[5]: https://ci.staging.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-release-ci-testing/49/
[6]: https://ci.staging.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-release-ci-testing/50/
[7]: https://ci.staging.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/2/
[8]: https://ci.staging.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-759-head/5/