### PR TITLE
Fix the reported build result in timestamp files

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -79,6 +79,13 @@ void main_record_timestamps(String job_name, Callable<Void> body) {
     timestamps {
         try {
             record_timestamps('main', job_name, body)
+        } catch (exception) {
+            /* If an exception has propagated this far without modifying the build result,
+             * set it to FAILED, so that archive_timestamps() reports it correctly. */
+            if (currentBuild.result == 'SUCCESS') {
+                currentBuild.result = 'FAILED'
+            }
+            throw exception
         } finally {
             stage('archive-timestamps') {
                 archive_timestamps()


### PR DESCRIPTION
The build result is only set to 'FAILED' if an exception propagates out of our groovy scripts, into Jenkins.

Set the result early, so that `archive_timestamps()` can report it correctly.