### PR TITLE
Only gather branch info once per job run

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -181,6 +181,10 @@ docker run -u \$(id -u):\$(id -g) -e MAKEFLAGS --rm --entrypoint $entrypoint \
 
 /* Get components of all.sh for a list of platforms*/
 def get_branch_information() {
+    if (all_all_sh_components) {
+        return
+    }
+
     node('container-host') {
         dir('src') {
             deleteDir()


### PR DESCRIPTION
The PR jobs gather a list of all.sh components twice in each build -this takes a while, as each docker container has to be downloaded onto the executor. Check if the map is already populated, and skip this step if so.