### PR TITLE
Add faketime package

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -89,6 +89,8 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
+        # to run tests in specific time.
+        faketime \
     && rm -rf /var/lib/apt/lists/
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -49,6 +49,8 @@ RUN apt-get update -q && apt-get install -yq \
         cmake \
         # to build Mbed TLS's documentation
         doxygen \
+        # to run tests in specific time.
+        faketime \
         # to cross-build Mbed TLS
         gcc-mingw-w64-i686 \
         # to check out Mbed TLS and others
@@ -89,8 +91,6 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
-        # to run tests in specific time.
-        faketime \
     && rm -rf /var/lib/apt/lists/
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -89,6 +89,8 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
+        # to run tests in specific time.
+        faketime \
     && rm -rf /var/lib/apt/lists/
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -49,6 +49,8 @@ RUN apt-get update -q && apt-get install -yq \
         cmake \
         # to build Mbed TLS's documentation
         doxygen \
+        # to run tests in specific time.
+        faketime \
         # to cross-build Mbed TLS
         gcc-mingw-w64-i686 \
         # to check out Mbed TLS and others
@@ -89,8 +91,6 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
-        # to run tests in specific time.
-        faketime \
     && rm -rf /var/lib/apt/lists/
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -55,6 +55,8 @@ RUN apt-get update -q && apt-get install -yq \
         cmake \
         # to build Mbed TLS's documentation
         doxygen \
+        # to run tests in specific time.
+        faketime \
         # to cross-build Mbed TLS
         gcc-mingw-w64-i686 \
         # to check out Mbed TLS and others
@@ -95,8 +97,6 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
-        # to run tests in specific time.
-        faketime \
     && rm -rf /var/lib/apt/lists/
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update -q && apt-get install -yq \
         # for Mbed TLS tests
         abi-compliance-checker \
         # Note that there is a known issue #5332 that stock abi tools
-        # in ubuntu20.04 do not fail as expected. 
+        # in ubuntu20.04 do not fail as expected.
         # https://github.com/ARMmbed/mbedtls/issues/5332
         # Do not activae 20.04 until that is resolved
         # to use with abi-compliance-tester
@@ -95,6 +95,8 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
+        # to run tests in specific time.
+        faketime \
     && rm -rf /var/lib/apt/lists/
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -55,6 +55,8 @@ RUN apt-get update -q && apt-get install -yq \
         cmake \
         # to build Mbed TLS's documentation
         doxygen \
+        # to run tests in specific time.
+        faketime \
         # to cross-build Mbed TLS
         gcc-mingw-w64-i686 \
         # to check out Mbed TLS and others
@@ -95,8 +97,6 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
-        # to run tests in specific time.
-        faketime \
     && rm -rf /var/lib/apt/lists/
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -95,6 +95,8 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
+        # to run tests in specific time.
+        faketime \
     && rm -rf /var/lib/apt/lists/
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.


### PR DESCRIPTION
This is prepare for [checking data_files](https://github.com/Mbed-TLS/mbedtls/issues/7729)

That script will run test with faketime

Test jobs on 6d32bea9647310e784e2d7e8eb05dc1fa03dd945 (running just Linux tests, since there are only Docker file updates):

* [OpenCI](https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-release-ci-testing/22/) → PASS
* [internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/496/) → PASS
