### PR TITLE
Port the Dockerfiles to aarch64

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /opt/src
 # destination for installing python dependencies
 ENV HOME=/var/lib/builds
 
-# Support for i386, for 32-bit builds+tests of Mbed TLS
+# Support for 32-bit builds+tests of Mbed TLS
 RUN case "$(uname -m)" in \
         x86_64)  dpkg --add-architecture i386;; \
         aarch64) dpkg --add-architecture armhf;; \

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /opt/src
 # destination for installing python dependencies
 ENV HOME=/var/lib/builds
 
-# Support for i386, for 32-bit builds+tests of Mbed TLS
+# Support for 32-bit builds+tests of Mbed TLS
 RUN case "$(uname -m)" in \
         x86_64)  dpkg --add-architecture i386;; \
         aarch64) dpkg --add-architecture armhf;; \

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /opt/src
 # destination for installing python dependencies
 ENV HOME=/var/lib/builds
 
-# Support for i386, for 32-bit builds+tests of Mbed TLS
+# Support for 32-bit builds+tests of Mbed TLS
 RUN case "$(uname -m)" in \
         x86_64)  dpkg --add-architecture i386;; \
         aarch64) dpkg --add-architecture armhf;; \

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /opt/src
 # destination for installing python dependencies
 ENV HOME=/var/lib/builds
 
-# Support for i386, for 32-bit builds+tests of Mbed TLS
+# Support for 32-bit builds+tests of Mbed TLS
 RUN case "$(uname -m)" in \
         x86_64)  dpkg --add-architecture i386;; \
         aarch64) dpkg --add-architecture armhf;; \


### PR DESCRIPTION
This allows us to build the Dockerfiles on aarch64 hosts, and run 32-bit and 64-bit Arm tests natively.

Supersedes #35.

Ci-runs: 
 - development
   - head
     - [Internal CI][1]
     - [OpenCI][6]
   - merge
     - [Internal CI][2]
     - [OpenCI][7]
   - deliberate ABI-break
     - [Internal CI][3]
     - [OpenCI][8]
 - 2.28
   - head
     - [Internal CI][4]
     - [OpenCI][9]
   - merge
     - [Internal CI][5]
     - [Open CI][10]
   
[1]:  https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-head/66/
[2]:  https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-merge/120/
[3]:  https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-758-merge/12/
[4]:  https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-850-head/5/
[5]:  https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-850-merge/10/
[6]:  https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/2/
[7]:  https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-merge/2/
[8]:  https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-758-merge/2/
[9]:  https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-850-head/2/
[10]: https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-850-merge/2/