### PR TITLE
Add xxd for data file regenerating tests

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -85,6 +85,8 @@ RUN apt-get update -q && apt-get install -yq \
         python3-pip \
         # for Mbed TLS tests
         valgrind \
+        # for data files generating. xxd is provide by vim
+        vim \
         # to download things installed from other places
         wget \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -87,6 +87,8 @@ RUN apt-get update -q && apt-get install -yq \
         valgrind \
         # to download things installed from other places
         wget \
+        # for data file generating
+        xxd \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -93,6 +93,8 @@ RUN apt-get update -q && apt-get install -yq \
         valgrind \
         # to download things installed from other places
         wget \
+        # for data file generating
+        xxd \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -93,6 +93,8 @@ RUN apt-get update -q && apt-get install -yq \
         valgrind \
         # to download things installed from other places
         wget \
+        # for data file generating
+        xxd \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)


### PR DESCRIPTION
`xxd` command is used for generating malformed data files. And https://github.com/Mbed-TLS/mbedtls/pull/7866 introduces tests for data files.