### PR TITLE
Add hexdump command

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -43,6 +43,8 @@ RUN apt-get update -q && apt-get install -yq \
         abi-dumper \
         # to build Mbed TLS: gcc, binutils, make, etc.
         build-essential \
+        # to generate malformed files
+        bsdmainutils \
         # to build Mbed TLS
         clang \
         # to build Mbed TLS

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -43,6 +43,8 @@ RUN apt-get update -q && apt-get install -yq \
         abi-dumper \
         # to build Mbed TLS: gcc, binutils, make, etc.
         build-essential \
+        # to generate malformed files
+        bsdmainutils \
         # to build Mbed TLS
         clang \
         # to build Mbed TLS

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -49,6 +49,8 @@ RUN apt-get update -q && apt-get install -yq \
         abi-dumper \
         # to build Mbed TLS: gcc, binutils, make, etc.
         build-essential \
+        # to generate malformed files
+        bsdmainutils \
         # to build Mbed TLS
         clang \
         # to build Mbed TLS

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -49,6 +49,8 @@ RUN apt-get update -q && apt-get install -yq \
         abi-dumper \
         # to build Mbed TLS: gcc, binutils, make, etc.
         build-essential \
+        # to generate malformed files
+        bsdextrautils \
         # to build Mbed TLS
         clang \
         # to build Mbed TLS


### PR DESCRIPTION
`hexdump` command is used for generating malformed data files. And https://github.com/Mbed-TLS/mbedtls/pull/7866 introduces tests for data files.

`hexdump` is provided by `bsdmainutils` or `bsdextrautils`. 