### PR TITLE
Add earliest and latest compilers

### DIFF
--- a/resources/docker_files/README.md
+++ b/resources/docker_files/README.md
@@ -17,7 +17,7 @@ See the [Quick Start section of the top-level README](../../README.md#quick-star
 
 A docker image can be built with following command:
 ```sh
-cd mbedtls-test/dev_envs/docker_files
+cd mbedtls-test/resources/docker_files
 sudo docker build --network=host -t ubuntu-18.04 -f ubuntu-18.04/Dockerfile .
 ```
 This creates an image from the specified file. The built image is maintained by docker in its own workspace on the host. Don't worry where the built image is gone! From this point the built image is referred by its tag name. For example `ubuntu-18.04`. See [Listing images](#listing-images) below.

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -48,10 +48,14 @@ RUN apt-get update -q && apt-get install -yq \
         autotools-dev \
         # to build Mbed TLS: gcc, binutils, make, etc.
         build-essential \
+        # to build Mbed TLS using earliest gcc version
+        gcc-4.7 \
         # to generate malformed files
         bsdmainutils \
         # to build Mbed TLS
         clang \
+        # to build Mbed TLS using earliest clang version
+        clang-3.5 \
         # to build Mbed TLS
         cmake \
         # to build Mbed TLS's documentation
@@ -112,7 +116,10 @@ RUN apt-get update -q && apt-get install -yq \
             libstdc++6:armhf \
             ;; \
     esac && \
-    rm -rf /var/lib/apt/lists/
+    rm -rf /var/lib/apt/lists/ && \
+    # create symbolic links for earliest gcc and clang versions
+    ln -s /usr/bin/gcc-4.7 /usr/local/bin/gcc-earliest && \
+    ln -s /usr/bin/clang-3.5 /usr/local/bin/clang-earliest 
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.
 # gcc-multilib conflicts with cross-compiler packages that we'll install later,

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -66,6 +66,8 @@ RUN apt-get update -q && apt-get install -yq \
         faketime \
         # to cross-build Mbed TLS
         gcc-mingw-w64-i686 \
+        # to build Mbed TLS using latest gcc version available from Ubuntu
+        gcc-12 \
         # to check out Mbed TLS and others
         git \
         # to build Mbed TLS's documentation
@@ -90,6 +92,8 @@ RUN apt-get update -q && apt-get install -yq \
         pkg-config \
         # to install Python packages
         python3-pip \
+        # provides some useful scripts for adding and removing repositories
+        software-properties-common \
         # for Mbed TLS tests
         valgrind \
         # to download things installed from other places
@@ -100,10 +104,6 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
-        # to build Mbed TLS using latest gcc version available from Ubuntu
-        gcc-12 \
-        # provides some useful scripts for adding and removing repositories
-        software-properties-common \
     && case "$(uname -m)" in \
         # x86_64 only packages
         x86_64) apt-get install -yq \
@@ -125,15 +125,15 @@ RUN apt-get update -q && apt-get install -yq \
     rm -rf /var/lib/apt/lists/ 
 
 # For installing clang-16, we add the llvm package source and add corresponding key 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 15CF4D18AF4F7421 \
-        # add an apt package source from https://apt.llvm.org/ 
-        &&  add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' -y \
-        &&  apt-get install -yq \
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 15CF4D18AF4F7421 && \
+    # add an apt package source from https://apt.llvm.org/ 
+    add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' -y && \
+    apt-get install -yq \
         # to build Mbed TLS using latest clang version at the time of writing
         clang-16 && \
-        # create symbolic links for latest gcc and clang versions
-        ln -s /usr/bin/clang-16 /usr/local/bin/clang-latest && \
-        ln -s /usr/bin/gcc-12 /usr/local/bin/gcc-latest
+    # create symbolic links for latest gcc and clang versions
+    ln -s /usr/bin/clang-16 /usr/local/bin/clang-latest && \
+    ln -s /usr/bin/gcc-12 /usr/local/bin/gcc-latest
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.
 # gcc-multilib conflicts with cross-compiler packages that we'll install later,

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -100,6 +100,10 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
+        # to build Mbed TLS using latest gcc version available from Ubuntu
+        gcc-12 \
+        # provides some useful scripts for adding and removing repositories
+        software-properties-common \
     && case "$(uname -m)" in \
         # x86_64 only packages
         x86_64) apt-get install -yq \
@@ -118,7 +122,18 @@ RUN apt-get update -q && apt-get install -yq \
             libstdc++6:armhf \
             ;; \
     esac && \
-    rm -rf /var/lib/apt/lists/
+    rm -rf /var/lib/apt/lists/ 
+
+# For installing clang-16, we add the llvm package source and add corresponding key 
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 15CF4D18AF4F7421 \
+        # add an apt package source from https://apt.llvm.org/ 
+        &&  add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' -y \
+        &&  apt-get install -yq \
+        # to build Mbed TLS using latest clang version at the time of writing
+        clang-16 && \
+        # create symbolic links for latest gcc and clang versions
+        ln -s /usr/bin/clang-16 /usr/local/bin/clang-latest && \
+        ln -s /usr/bin/gcc-12 /usr/local/bin/gcc-latest
 
 # Install all the parts of gcc-multilib, which is necessary for 32-bit builds.
 # gcc-multilib conflicts with cross-compiler packages that we'll install later,


### PR DESCRIPTION
This commit updates the Ubuntu 16.04 docker file to include the earliest versions of GCC (4.7) and Clang (3.5) available in 16.04. For Ubuntu 22.04 the latest compiler versions of GCC (12) and Clang (16) are installed.

Also creates couple of symlinks of those compilers for simplified usage in the all.sh script.

`all.sh` will start using the new compiler versions in https://github.com/Mbed-TLS/mbedtls/pull/7968 and https://github.com/Mbed-TLS/mbedtls/pull/7969.

Resolves #110 