### PR TITLE
Fix error reporting in case a branch is deleted while being tested

### DIFF
--- a/vars/checkout_repo.groovy
+++ b/vars/checkout_repo.groovy
@@ -17,9 +17,24 @@
  *  This file is part of Mbed TLS (https://www.trustedfirmware.org/projects/mbed-tls/)
  */
 
+import hudson.model.Result
+import hudson.scm.NullSCM
+import jenkins.model.CauseOfInterruption
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+
+void checkout_scm_not_null() {
+    if (scm instanceof NullSCM) {
+        echo 'scm is NullSCM - branch was deleted while being tested'
+        /* Color the stage yellow */
+        throw new FlowInterruptedException(Result.UNSTABLE, new CauseOfInterruption[0])
+    } else {
+        checkout scm
+    }
+}
+
 def checkout_repo() {
     if (env.TARGET_REPO == 'tls' && env.CHECKOUT_METHOD == 'scm') {
-        checkout scm
+        checkout_scm_not_null()
     } else {
         checkout_parametrized_repo(MBED_TLS_REPO, MBED_TLS_BRANCH)
     }
@@ -27,7 +42,7 @@ def checkout_repo() {
 
 def checkout_mbed_os_example_repo(repo, branch) {
     if (env.TARGET_REPO == 'example' && env.CHECKOUT_METHOD == 'scm') {
-        checkout scm
+        checkout_scm_not_null()
     } else {
         checkout_parametrized_repo(repo, branch)
     }

--- a/vars/checkout_repo.groovy
+++ b/vars/checkout_repo.groovy
@@ -22,53 +22,60 @@ import hudson.scm.NullSCM
 import jenkins.model.CauseOfInterruption
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 
-void checkout_scm_not_null() {
-    if (scm instanceof NullSCM) {
+Map<String, String> checkout_report_errors(scm_config) {
+    if (scm_config instanceof NullSCM) {
         echo 'scm is NullSCM - branch was deleted while being tested'
         /* Color the stage yellow */
         throw new FlowInterruptedException(Result.UNSTABLE, new CauseOfInterruption[0])
     } else {
-        checkout scm
+        try {
+            return checkout(scm_config)
+        } catch (exception) {
+            echo "Git checkout failed (branch deleted / network error?): ${common.stack_trace_to_string(exception)}"
+            throw new FlowInterruptedException(Result.UNSTABLE, new CauseOfInterruption[0])
+        }
     }
 }
 
-def checkout_repo() {
+Map<String, String> checkout_repo() {
+    def scm_config
     if (env.TARGET_REPO == 'tls' && env.CHECKOUT_METHOD == 'scm') {
-        checkout_scm_not_null()
+        scm_config = scm
     } else {
-        checkout_parametrized_repo(MBED_TLS_REPO, MBED_TLS_BRANCH)
+        scm_config = parametrized_repo(env.MBED_TLS_REPO, env.MBED_TLS_BRANCH)
     }
+    return checkout_report_errors(scm_config)
 }
 
-def checkout_mbed_os_example_repo(repo, branch) {
+Map<String, String> checkout_mbed_os_example_repo(String repo, String branch) {
+    def scm_config
     if (env.TARGET_REPO == 'example' && env.CHECKOUT_METHOD == 'scm') {
-        checkout_scm_not_null()
+        scm_config = scm
     } else {
-        checkout_parametrized_repo(repo, branch)
+        scm_config = parametrized_repo(repo, branch)
     }
+    return checkout_report_errors(scm_config)
 }
 
-def checkout_parametrized_repo(repo, branch) {
-    checkout([
-        scm: [
-            $class: 'GitSCM',
-            userRemoteConfigs: [[
-                url: repo,
-                refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/pull/*',
-                credentialsId: env.GIT_CREDENTIALS_ID
-            ]],
-            branches: [[name: branch]],
-            extensions: [
-                [$class: 'CloneOption', timeout: 60],
-                [$class: 'SubmoduleOption', recursiveSubmodules: true],
-                [$class: 'LocalBranch', localBranch: branch],
-            ],
-        ]
-    ])
+Map<String, Object> parametrized_repo(String repo, String branch) {
+    return [
+        $class: 'GitSCM',
+        userRemoteConfigs: [[
+            url: repo,
+            refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/pull/*',
+            credentialsId: env.GIT_CREDENTIALS_ID
+        ]],
+        branches: [[name: branch]],
+        extensions: [
+            [$class: 'CloneOption', timeout: 60],
+            [$class: 'SubmoduleOption', recursiveSubmodules: true],
+            [$class: 'LocalBranch', localBranch: '**'],
+        ],
+    ]
 }
 
 def checkout_mbed_os() {
-    checkout([
+    checkout_report_errors([
         scm: [
             $class: 'GitSCM',
             userRemoteConfigs: [
@@ -85,7 +92,7 @@ def checkout_mbed_os() {
             dir('TARGET_IGNORE/mbedtls')
             {
                 deleteDir()
-                checkout_mbedtls_repo()
+                checkout_repo()
             }
             sh """\
 ulimit -f 20971520

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -23,7 +23,6 @@ import groovy.transform.Field
 
 import com.cloudbees.groovy.cps.NonCPS
 import hudson.AbortException
-import hudson.plugins.git.GitSCM
 
 /* Indicates if CI is running on Open CI (hosted on https://ci.trustedfirmware.org/) */
 @Field is_open_ci_env = env.JENKINS_URL ==~ /\S+(trustedfirmware)\S+/
@@ -309,16 +308,13 @@ void maybe_notify_github(String state, String description, String context=null) 
         context = "$ci: $job"
     }
 
-    /* Set owner and repository explicitly in case the multibranch pipeline uses multiple repos
-     * Needed for testing Github merge queues */
-    def (account, repo) = ((GitSCM) scm).userRemoteConfigs[0].url.replaceFirst(/.*:/, '').split('/')[-2..-1]
-    repo = repo.replaceFirst(/\.git$/, '')
-
     githubNotify context: context,
                  status: state,
                  description: description,
-                 account: account,
-                 repo: repo
+                /* Set owner and repository explicitly in case the multibranch pipeline uses multiple repos
+-                * Needed for testing Github merge queues */
+                 account: env.GITHUB_ORG,
+                 repo: env.GITHUB_REPO
 }
 
 def archive_zipped_log_files(job_name) {

--- a/vars/environ.groovy
+++ b/vars/environ.groovy
@@ -17,6 +17,8 @@
  *  This file is part of Mbed TLS (https://www.trustedfirmware.org/projects/mbed-tls/)
  */
 
+import hudson.plugins.git.GitSCM
+
 def set_common_environment() {
     /* Do moderately parallel builds. This overrides the default in all.sh
      * which is to do maximally parallel builds (-j). Massively parallel builds
@@ -47,6 +49,15 @@ def set_common_pr_production_environment() {
         env.RUN_FREEBSD = 'true'
         env.RUN_WINDOWS_TEST = 'true'
         env.RUN_ALL_SH = 'true'
+    }
+    /* Extract owner and repository from the repo url - needed for testing Github merge queues
+     * "scm" might degenerate to a NullSCM object if the branch we are testing is deleted durin the test.
+     *  This tends to happen during merge queue runs */
+    if (scm instanceof GitSCM) {
+        def (org, repo) = scm.userRemoteConfigs[0].url.replaceFirst(/.*:/, '').split('/')[-2..-1]
+        repo = repo.replaceFirst(/\.git$/, '')
+        env.GITHUB_ORG = org
+        env.GITHUB_REPO = repo
     }
 }
 

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -78,6 +78,7 @@ def run_pr_job(is_production=true) {
                 ])
             }
 
+            environ.set_tls_pr_environment(is_production)
             common.maybe_notify_github('PENDING', 'In progress')
 
             if (!common.is_open_ci_env && env.BRANCH_NAME ==~ /gh-readonly-queue\/.*/) {
@@ -95,7 +96,6 @@ def run_pr_job(is_production=true) {
             common.init_docker_images()
 
             stage('pre-test-checks') {
-                environ.set_tls_pr_environment(is_production)
                 common.get_branch_information()
                 common.check_every_all_sh_component_will_be_run()
             }


### PR DESCRIPTION
We report test failures to Github early, which causes Github to delete merge queue branches while they are still being tested. These deletions are reported to Jenkins via webhooks, which causes the `scm` variable to degenerate into a [NullSCM][1] object.

Handle such cases by extracting the needed information from `scm` early, and checking for the `NullSCM` type when performing checkouts.

This patch marks stages where we attempted to check out a NullSCM object as "unstable", which shows up as yellow on Blue Ocean. This helps quickly identify the  test that originally caused the failure (since its stage will show up as red).

~~At the time of writing, the stages on OpenCI turn yellow, as intended -  but the Internal CI needs a (fairly trivial) plugin upgrade for the stages to show up as yellow (UNSTABLE), rather than red (FAILED).~~

~~JIRA ticket for the Internal CI plugin upgrade: [OSSDEVOPS-6751][2]~~

[1]: https://javadoc.jenkins.io/hudson/scm/NullSCM.html
[2]: https://jira.arm.com/browse/OSSDEVOPS-6751

Test runs:
- [Internal CI merge queue Failure][3]
- [Open CI merge queue Failure][4]

[3]: https://jenkins-mbedtls.oss.arm.com/blue/organizations/jenkins/mbed-tls-pr-ci-testing/detail/gh-readonly-queue%2Fdev%2Fbensze01%2Fmerge-queue-test%2Fpr-7959-07c2bea18c0277686dc42d9d88ff0b6798700f29/1/pipeline/
[4]: https://mbedtls.trustedfirmware.org/blue/organizations/jenkins/mbed-tls-restricted-pr-ci-testing/detail/gh-readonly-queue%2Fdev%2Fbensze01%2Fmerge-queue-test%2Fpr-7959-07c2bea18c0277686dc42d9d88ff0b6798700f29/1/pipeline/