### PR TITLE
Update OPENSSL_NEXT to 3.1.2

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -185,14 +185,14 @@ RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
 
 ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
 
-# Install openssl 1.1.1a - "next" version
-RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
-    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
-    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+# Install openssl 3.1.2 - "next" version
+RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
+    tar -zxf openssl-3.1.2.tar.gz && cd openssl-3.1.2 && \
+    ./config --prefix=/usr/local/openssl-3.1.2 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
     make clean && make && make install && cd .. && \
-    rm -rf openssl-1.1.1a*
+    rm -rf openssl-3.1.2*
 
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_NEXT=/usr/local/openssl-3.1.2/bin/openssl
 
 # Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -184,14 +184,14 @@ RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
 
 ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
 
-# Install openssl 1.1.1a - "next" version
-RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
-    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
-    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+# Install openssl 3.1.2 - "next" version
+RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
+    tar -zxf openssl-3.1.2.tar.gz && cd openssl-3.1.2 && \
+    ./config --prefix=/usr/local/openssl-3.1.2 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
     make clean && make && make install && cd .. && \
-    rm -rf openssl-1.1.1a*
+    rm -rf openssl-3.1.2*
 
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_NEXT=/usr/local/openssl-3.1.2/bin/openssl
 
 # Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -186,14 +186,14 @@ RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
 
 ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
 
-# Install openssl 1.1.1a - "next" version
-RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
-    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
-    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+# Install openssl 3.1.2 - "next" version
+RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
+    tar -zxf openssl-3.1.2.tar.gz && cd openssl-3.1.2 && \
+    ./config --prefix=/usr/local/openssl-3.1.2 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
     make clean && make && make install && cd .. && \
-    rm -rf openssl-1.1.1a*
+    rm -rf openssl-3.1.2*
 
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_NEXT=/usr/local/openssl-3.1.2/bin/openssl
 
 # Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -201,14 +201,14 @@ RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
 
 ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
 
-# Install openssl 1.1.1a - "next" version
-RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
-    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
-    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+# Install openssl 3.1.2 - "next" version
+RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
+    tar -zxf openssl-3.1.2.tar.gz && cd openssl-3.1.2 && \
+    ./config --prefix=/usr/local/openssl-3.1.2 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
     make clean && make && make install && cd .. && \
-    rm -rf openssl-1.1.1a*
+    rm -rf openssl-3.1.2*
 
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_NEXT=/usr/local/openssl-3.1.2/bin/openssl
 
 # Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \


### PR DESCRIPTION
Fixes [#7350](https://github.com/Mbed-TLS/mbedtls/issues/7350).

OpenSSL 1.1.1 is reaching EOL in September so all the docker images are updated to use the latest available OpenSSL version as OPENSSL_NEXT.