### PR TITLE
Use version numbers in $OPENSSL and $GNUTLS variables; add OpenSSL 3.0 and 3.1

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -155,7 +155,32 @@ RUN apt-get update -q && apt-get install -yq \
 # Distro packages tend to include patches that disrupt our testing scripts,
 # and such patches may be added at any time. Avoid surprises by using fixed
 # versions.
-#
+
+# Install openssl 1.0.1j - "legacy" version
+RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
+    tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
+    ./config --openssldir=/usr/local/openssl-1.0.1j && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.0.1j*
+ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
+
+# Install openssl 1.0.2g - main version, in the PATH
+RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
+    tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
+    ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.0.2g*
+ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
+ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
+
+# Install openssl 1.1.1a - "next" version
+RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
+    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
+    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.1.1a*
+ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
+
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each
 # version of GnuTLS that we want.
@@ -165,34 +190,6 @@ RUN apt-get update -q && apt-get install -yq \
 # - p11-kit: optional, for smart-card support - configure it out
 # - libunistring: since 3.6 - the Ubuntu package works; if it didn't a config
 # option --with-included-libunistring is available.
-
-# Install openssl 1.0.2g - main version, in the PATH
-RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
-    tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
-    ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.0.2g*
-
-ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
-ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
-
-# Install openssl 1.0.1j - "legacy" version
-RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
-    tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
-    ./config --openssldir=/usr/local/openssl-1.0.1j && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.0.1j*
-
-ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
-
-# Install openssl 1.1.1a - "next" version
-RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
-    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
-    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.1.1a*
-
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 # Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
@@ -205,7 +202,6 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.10*
-
 ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
 ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
@@ -227,7 +223,6 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.7.2 --exec_prefix=/usr/local/gnutls-3.7.2 --disable-shared --with-included-libtasn1 --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.7.2*
-
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -212,27 +212,27 @@ ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
 # - libunistring: since 3.6 - the Ubuntu package works; if it didn't a config
 # option --with-included-libunistring is available.
 
-# Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
+# Install Gnu TLS 3.4.6 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     tar -zxf nettle-3.1.tar.gz && cd nettle-3.1 && \
     ./configure --prefix=/usr/local/libnettle-3.1 --exec_prefix=/usr/local/libnettle-3.1  --disable-shared --disable-openssl && \
     make && make install && cd .. && rm -rf nettle-3.1* && \
     export PKG_CONFIG_PATH=/usr/local/libnettle-3.1/lib/pkgconfig:/usr/local/libnettle-3.1/lib64/pkgconfig:/usr/local/lib/pkgconfig && \
-    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.10.tar.xz && \
-    tar -xJf gnutls-3.4.10.tar.xz && cd gnutls-3.4.10 && \
-    ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
+    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.6.tar.xz && \
+    tar -xJf gnutls-3.4.6.tar.xz && cd gnutls-3.4.6 && \
+    ./configure --prefix=/usr/local/gnutls-3.4.6 --exec_prefix=/usr/local/gnutls-3.4.6 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
-    rm -rf gnutls-3.4.10*
-ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.10.
-ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+    rm -rf gnutls-3.4.6*
+ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.6.
+ENV GNUTLS_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 
 # For backward compatibility with older all.sh. At the time of writing,
-# GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
+# GnuTLS 3.4.6 works fine as the "legacy" version, and newer all.sh will
 # stop using a separate GNUTLS_LEGACY_xxx pair of programs.
 ENV GNUTLS_LEGACY_CLI=$GNUTLS_CLI
 ENV GNUTLS_LEGACY_SERV=$GNUTLS_SERV

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -223,8 +223,8 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.6 --exec_prefix=/usr/local/gnutls-3.4.6 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.6*
-ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
-ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+ENV GNUTLS_3_4_6_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_6_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
 ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 # Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.6.

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -156,29 +156,33 @@ RUN apt-get update -q && apt-get install -yq \
 # and such patches may be added at any time. Avoid surprises by using fixed
 # versions.
 
-# Install openssl 1.0.1j - "legacy" version
 RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
     tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
     ./config --openssldir=/usr/local/openssl-1.0.1j && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.0.1j*
+ENV OPENSSL_1_0_1=/usr/local/openssl-1.0.1j/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL_LEGACY is 1.0.1j.
 ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
 
-# Install openssl 1.0.2g - main version, in the PATH
 RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
     tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
     ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.0.2g*
+ENV OPENSSL_1_0_2=/usr/local/openssl-1.0.2g/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL is 1.0.2g.
 ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
-ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
 
-# Install openssl 1.1.1a - "next" version
 RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
     tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
     ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.1.1a*
+ENV OPENSSL_1_1_1=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_1_1=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
 ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 # GnuTLS has a number of (optional) dependencies:
@@ -202,9 +206,13 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.10*
+ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
+ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
+ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.10.
 ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
 
 # For backward compatibility with older all.sh. At the time of writing,
 # GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
@@ -223,6 +231,13 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.7.2 --exec_prefix=/usr/local/gnutls-3.7.2 --disable-shared --with-included-libtasn1 --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.7.2*
+ENV GNUTLS_3_7_2_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_7_2_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+ENV GNUTLS_3_7_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_7_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+ENV GNUTLS_3_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_NEXT_xxx is 3.7.2.
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -210,23 +210,11 @@ ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
 ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
 
-# Install Gnu TLS 3.3.8 (nettle 2.7) - "legacy" version
-RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz && \
-    tar -zxf nettle-2.7.1.tar.gz && cd nettle-2.7.1 && \
-    # Update autoconf to support building on aarch64
-    cp -f /usr/share/misc/config.sub . && \
-    cp -f /usr/share/misc/config.guess . && \
-    ./configure --prefix=/usr/local/libnettle-2.7.1 --exec_prefix=/usr/local/libnettle-2.7.1  --disable-shared --disable-openssl && \
-    make && make install && cd .. && rm -rf nettle-2.7.1* && \
-    export PKG_CONFIG_PATH=/usr/local/libnettle-2.7.1/lib/pkgconfig:/usr/local/libnettle-2.7.1/lib64/pkgconfig:/usr/local/lib/pkgconfig && \
-    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.3/gnutls-3.3.8.tar.xz && \
-    tar -xJf gnutls-3.3.8.tar.xz && cd gnutls-3.3.8 && \
-    ./configure --prefix=/usr/local/gnutls-3.3.8 --exec_prefix=/usr/local/gnutls-3.3.8 --disable-shared --without-p11-kit && \
-    make && make install && cat config.log && cd .. && \
-    rm -rf gnutls-3.3.8*
-
-ENV GNUTLS_LEGACY_CLI=/usr/local/gnutls-3.3.8/bin/gnutls-cli
-ENV GNUTLS_LEGACY_SERV=/usr/local/gnutls-3.3.8/bin/gnutls-serv
+# For backward compatibility with older all.sh. At the time of writing,
+# GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
+# stop using a separate GNUTLS_LEGACY_xxx pair of programs.
+ENV GNUTLS_LEGACY_CLI=$GNUTLS_CLI
+ENV GNUTLS_LEGACY_SERV=$GNUTLS_SERV
 
 # Instal GNU TLS 3.7.2 (nettle 3.7) - "next" version
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -185,6 +185,23 @@ ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
 # Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
 ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
+RUN wget -q https://www.openssl.org/source/openssl-3.0.10.tar.gz && \
+    tar -zxf openssl-3.0.10.tar.gz && cd openssl-3.0.10 && \
+    ./config --prefix=/usr/local/openssl-3.0.10 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-3.0.10*
+ENV OPENSSL_3_0_10=/usr/local/openssl-3.0.10/bin/openssl
+ENV OPENSSL_3_0=/usr/local/openssl-3.0.10/bin/openssl
+
+RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
+    tar -zxf openssl-3.1.2.tar.gz && cd openssl-3.1.2 && \
+    ./config --prefix=/usr/local/openssl-3.1.2 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-3.1.2*
+ENV OPENSSL_3_1_2=/usr/local/openssl-3.1.2/bin/openssl
+ENV OPENSSL_3_1=/usr/local/openssl-3.1.2/bin/openssl
+ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
+
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each
 # version of GnuTLS that we want.

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -222,8 +222,8 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.6 --exec_prefix=/usr/local/gnutls-3.4.6 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.6*
-ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
-ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+ENV GNUTLS_3_4_6_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_6_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
 ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 # Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.6.

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -209,23 +209,11 @@ ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
 ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
 
-# Install Gnu TLS 3.3.8 (nettle 2.7) - "legacy" version
-RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz && \
-    tar -zxf nettle-2.7.1.tar.gz && cd nettle-2.7.1 && \
-    # Update autoconf to support building on aarch64
-    cp -f /usr/share/misc/config.sub . && \
-    cp -f /usr/share/misc/config.guess . && \
-    ./configure --prefix=/usr/local/libnettle-2.7.1 --exec_prefix=/usr/local/libnettle-2.7.1  --disable-shared --disable-openssl && \
-    make && make install && cd .. && rm -rf nettle-2.7.1* && \
-    export PKG_CONFIG_PATH=/usr/local/libnettle-2.7.1/lib/pkgconfig:/usr/local/libnettle-2.7.1/lib64/pkgconfig:/usr/local/lib/pkgconfig && \
-    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.3/gnutls-3.3.8.tar.xz && \
-    tar -xJf gnutls-3.3.8.tar.xz && cd gnutls-3.3.8 && \
-    ./configure --prefix=/usr/local/gnutls-3.3.8 --exec_prefix=/usr/local/gnutls-3.3.8 --disable-shared --without-p11-kit && \
-    make && make install && cat config.log && cd .. && \
-    rm -rf gnutls-3.3.8*
-
-ENV GNUTLS_LEGACY_CLI=/usr/local/gnutls-3.3.8/bin/gnutls-cli
-ENV GNUTLS_LEGACY_SERV=/usr/local/gnutls-3.3.8/bin/gnutls-serv
+# For backward compatibility with older all.sh. At the time of writing,
+# GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
+# stop using a separate GNUTLS_LEGACY_xxx pair of programs.
+ENV GNUTLS_LEGACY_CLI=$GNUTLS_CLI
+ENV GNUTLS_LEGACY_SERV=$GNUTLS_SERV
 
 # Instal GNU TLS 3.7.2 (nettle 3.7) - "next" version
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -211,27 +211,27 @@ ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
 # - libunistring: since 3.6 - the Ubuntu package works; if it didn't a config
 # option --with-included-libunistring is available.
 
-# Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
+# Install Gnu TLS 3.4.6 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     tar -zxf nettle-3.1.tar.gz && cd nettle-3.1 && \
     ./configure --prefix=/usr/local/libnettle-3.1 --exec_prefix=/usr/local/libnettle-3.1  --disable-shared --disable-openssl && \
     make && make install && cd .. && rm -rf nettle-3.1* && \
     export PKG_CONFIG_PATH=/usr/local/libnettle-3.1/lib/pkgconfig:/usr/local/libnettle-3.1/lib64/pkgconfig:/usr/local/lib/pkgconfig && \
-    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.10.tar.xz && \
-    tar -xJf gnutls-3.4.10.tar.xz && cd gnutls-3.4.10 && \
-    ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
+    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.6.tar.xz && \
+    tar -xJf gnutls-3.4.6.tar.xz && cd gnutls-3.4.6 && \
+    ./configure --prefix=/usr/local/gnutls-3.4.6 --exec_prefix=/usr/local/gnutls-3.4.6 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
-    rm -rf gnutls-3.4.10*
-ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.10.
-ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+    rm -rf gnutls-3.4.6*
+ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.6.
+ENV GNUTLS_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 
 # For backward compatibility with older all.sh. At the time of writing,
-# GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
+# GnuTLS 3.4.6 works fine as the "legacy" version, and newer all.sh will
 # stop using a separate GNUTLS_LEGACY_xxx pair of programs.
 ENV GNUTLS_LEGACY_CLI=$GNUTLS_CLI
 ENV GNUTLS_LEGACY_SERV=$GNUTLS_SERV

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -156,29 +156,33 @@ RUN wget -q https://github.com/lvc/abi-compliance-checker/archive/2.3.tar.gz && 
 # and such patches may be added at any time. Avoid surprises by using fixed
 # versions.
 
-# Install openssl 1.0.1j - "legacy" version
 RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
     tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
     ./config --openssldir=/usr/local/openssl-1.0.1j && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.0.1j*
+ENV OPENSSL_1_0_1=/usr/local/openssl-1.0.1j/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL_LEGACY is 1.0.1j.
 ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
 
-# Install openssl 1.0.2g - main version, in the PATH
 RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
     tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
     ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.0.2g*
+ENV OPENSSL_1_0_2=/usr/local/openssl-1.0.2g/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL is 1.0.2g.
 ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
-ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
 
-# Install openssl 1.1.1a - "next" version
 RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
     tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
     ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.1.1a*
+ENV OPENSSL_1_1_1=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_1_1=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
 ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 # GnuTLS has a number of (optional) dependencies:
@@ -201,9 +205,13 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.10*
+ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
+ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
+ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.10.
 ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
 
 # For backward compatibility with older all.sh. At the time of writing,
 # GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
@@ -222,6 +230,13 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.7.2 --exec_prefix=/usr/local/gnutls-3.7.2 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.7.2*
+ENV GNUTLS_3_7_2_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_7_2_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+ENV GNUTLS_3_7_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_7_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+ENV GNUTLS_3_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_NEXT_xxx is 3.7.2.
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -155,7 +155,32 @@ RUN wget -q https://github.com/lvc/abi-compliance-checker/archive/2.3.tar.gz && 
 # Distro packages tend to include patches that disrupt our testing scripts,
 # and such patches may be added at any time. Avoid surprises by using fixed
 # versions.
-#
+
+# Install openssl 1.0.1j - "legacy" version
+RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
+    tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
+    ./config --openssldir=/usr/local/openssl-1.0.1j && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.0.1j*
+ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
+
+# Install openssl 1.0.2g - main version, in the PATH
+RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
+    tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
+    ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.0.2g*
+ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
+ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
+
+# Install openssl 1.1.1a - "next" version
+RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
+    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
+    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.1.1a*
+ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
+
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each
 # version of GnuTLS that we want.
@@ -164,34 +189,6 @@ RUN wget -q https://github.com/lvc/abi-compliance-checker/archive/2.3.tar.gz && 
 # - p11-kit: optional, for smart-card support - configure it out
 # - libunistring: since 3.6 - the Ubuntu package works; if it didn't a config
 # option --with-included-libunistring is available.
-
-# Install openssl 1.0.2g - main version, in the PATH
-RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
-    tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
-    ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.0.2g*
-
-ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
-ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
-
-# Install openssl 1.0.1j - "legacy" version
-RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
-    tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
-    ./config --openssldir=/usr/local/openssl-1.0.1j && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.0.1j*
-
-ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
-
-# Install openssl 1.1.1a - "next" version
-RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
-    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
-    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.1.1a*
-
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 # Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
@@ -204,7 +201,6 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.10*
-
 ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
 ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
@@ -226,7 +222,6 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.7.2 --exec_prefix=/usr/local/gnutls-3.7.2 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.7.2*
-
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -185,6 +185,23 @@ ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
 # Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
 ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
+RUN wget -q https://www.openssl.org/source/openssl-3.0.10.tar.gz && \
+    tar -zxf openssl-3.0.10.tar.gz && cd openssl-3.0.10 && \
+    ./config --prefix=/usr/local/openssl-3.0.10 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-3.0.10*
+ENV OPENSSL_3_0_10=/usr/local/openssl-3.0.10/bin/openssl
+ENV OPENSSL_3_0=/usr/local/openssl-3.0.10/bin/openssl
+
+RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
+    tar -zxf openssl-3.1.2.tar.gz && cd openssl-3.1.2 && \
+    ./config --prefix=/usr/local/openssl-3.1.2 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-3.1.2*
+ENV OPENSSL_3_1_2=/usr/local/openssl-3.1.2/bin/openssl
+ENV OPENSSL_3_1=/usr/local/openssl-3.1.2/bin/openssl
+ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
+
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each
 # version of GnuTLS that we want.

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -211,23 +211,11 @@ ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
 ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
 
-# Install Gnu TLS 3.3.8 (nettle 2.7) - "legacy" version
-RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz && \
-    tar -zxf nettle-2.7.1.tar.gz && cd nettle-2.7.1 && \
-    # Update autoconf to support building on aarch64
-    cp -f /usr/share/misc/config.sub . && \
-    cp -f /usr/share/misc/config.guess . && \
-    ./configure --prefix=/usr/local/libnettle-2.7.1 --exec_prefix=/usr/local/libnettle-2.7.1  --disable-shared --disable-openssl && \
-    make && make install && cd .. && rm -rf nettle-2.7.1* && \
-    export PKG_CONFIG_PATH=/usr/local/libnettle-2.7.1/lib/pkgconfig:/usr/local/libnettle-2.7.1/lib64/pkgconfig:/usr/local/lib/pkgconfig && \
-    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.3/gnutls-3.3.8.tar.xz && \
-    tar -xJf gnutls-3.3.8.tar.xz && cd gnutls-3.3.8 && \
-    ./configure --prefix=/usr/local/gnutls-3.3.8 --exec_prefix=/usr/local/gnutls-3.3.8 --disable-shared --without-p11-kit && \
-    make && make install && cat config.log && cd .. && \
-    rm -rf gnutls-3.3.8*
-
-ENV GNUTLS_LEGACY_CLI=/usr/local/gnutls-3.3.8/bin/gnutls-cli
-ENV GNUTLS_LEGACY_SERV=/usr/local/gnutls-3.3.8/bin/gnutls-serv
+# For backward compatibility with older all.sh. At the time of writing,
+# GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
+# stop using a separate GNUTLS_LEGACY_xxx pair of programs.
+ENV GNUTLS_LEGACY_CLI=$GNUTLS_CLI
+ENV GNUTLS_LEGACY_SERV=$GNUTLS_SERV
 
 # Instal GNU TLS 3.7.2 (nettle 3.7) - "next" version
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -224,8 +224,8 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.6 --exec_prefix=/usr/local/gnutls-3.4.6 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.6*
-ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
-ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+ENV GNUTLS_3_4_6_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_6_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
 ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 # Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.6.

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -158,29 +158,33 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
 # and such patches may be added at any time. Avoid surprises by using fixed
 # versions.
 
-# Install openssl 1.0.1j - "legacy" version
 RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
     tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
     ./config --openssldir=/usr/local/openssl-1.0.1j && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.0.1j*
+ENV OPENSSL_1_0_1=/usr/local/openssl-1.0.1j/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL_LEGACY is 1.0.1j.
 ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
 
-# Install openssl 1.0.2g - main version, in the PATH
 RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
     tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
     ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.0.2g*
+ENV OPENSSL_1_0_2=/usr/local/openssl-1.0.2g/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL is 1.0.2g.
 ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
-ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
 
-# Install openssl 1.1.1a - "next" version
 RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
     tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
     ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.1.1a*
+ENV OPENSSL_1_1_1=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_1_1=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
 ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 # GnuTLS has a number of (optional) dependencies:
@@ -203,9 +207,13 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.10*
+ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
+ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
+ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.10.
 ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
 
 # For backward compatibility with older all.sh. At the time of writing,
 # GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
@@ -224,6 +232,13 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.7.2 --exec_prefix=/usr/local/gnutls-3.7.2 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.7.2*
+ENV GNUTLS_3_7_2_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_7_2_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+ENV GNUTLS_3_7_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_7_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+ENV GNUTLS_3_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_NEXT_xxx is 3.7.2.
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -157,7 +157,32 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
 # Distro packages tend to include patches that disrupt our testing scripts,
 # and such patches may be added at any time. Avoid surprises by using fixed
 # versions.
-#
+
+# Install openssl 1.0.1j - "legacy" version
+RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
+    tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
+    ./config --openssldir=/usr/local/openssl-1.0.1j && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.0.1j*
+ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
+
+# Install openssl 1.0.2g - main version, in the PATH
+RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
+    tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
+    ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.0.2g*
+ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
+ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
+
+# Install openssl 1.1.1a - "next" version
+RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
+    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
+    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.1.1a*
+ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
+
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each
 # version of GnuTLS that we want.
@@ -166,34 +191,6 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
 # - p11-kit: optional, for smart-card support - configure it out
 # - libunistring: since 3.6 - the Ubuntu package works; if it didn't a config
 # option --with-included-libunistring is available.
-
-# Install openssl 1.0.2g - main version, in the PATH
-RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
-    tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
-    ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.0.2g*
-
-ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
-ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
-
-# Install openssl 1.0.1j - "legacy" version
-RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
-    tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
-    ./config --openssldir=/usr/local/openssl-1.0.1j && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.0.1j*
-
-ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
-
-# Install openssl 1.1.1a - "next" version
-RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
-    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
-    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.1.1a*
-
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 # Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
@@ -206,7 +203,6 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.10*
-
 ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
 ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
@@ -228,7 +224,6 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.7.2 --exec_prefix=/usr/local/gnutls-3.7.2 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.7.2*
-
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -187,6 +187,23 @@ ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
 # Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
 ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
+RUN wget -q https://www.openssl.org/source/openssl-3.0.10.tar.gz && \
+    tar -zxf openssl-3.0.10.tar.gz && cd openssl-3.0.10 && \
+    ./config --prefix=/usr/local/openssl-3.0.10 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-3.0.10*
+ENV OPENSSL_3_0_10=/usr/local/openssl-3.0.10/bin/openssl
+ENV OPENSSL_3_0=/usr/local/openssl-3.0.10/bin/openssl
+
+RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
+    tar -zxf openssl-3.1.2.tar.gz && cd openssl-3.1.2 && \
+    ./config --prefix=/usr/local/openssl-3.1.2 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-3.1.2*
+ENV OPENSSL_3_1_2=/usr/local/openssl-3.1.2/bin/openssl
+ENV OPENSSL_3_1=/usr/local/openssl-3.1.2/bin/openssl
+ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
+
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each
 # version of GnuTLS that we want.

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -213,27 +213,27 @@ ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
 # - libunistring: since 3.6 - the Ubuntu package works; if it didn't a config
 # option --with-included-libunistring is available.
 
-# Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
+# Install Gnu TLS 3.4.6 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     tar -zxf nettle-3.1.tar.gz && cd nettle-3.1 && \
     ./configure --prefix=/usr/local/libnettle-3.1 --exec_prefix=/usr/local/libnettle-3.1  --disable-shared --disable-openssl && \
     make && make install && cd .. && rm -rf nettle-3.1* && \
     export PKG_CONFIG_PATH=/usr/local/libnettle-3.1/lib/pkgconfig:/usr/local/libnettle-3.1/lib64/pkgconfig:/usr/local/lib/pkgconfig && \
-    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.10.tar.xz && \
-    tar -xJf gnutls-3.4.10.tar.xz && cd gnutls-3.4.10 && \
-    ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
+    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.6.tar.xz && \
+    tar -xJf gnutls-3.4.6.tar.xz && cd gnutls-3.4.6 && \
+    ./configure --prefix=/usr/local/gnutls-3.4.6 --exec_prefix=/usr/local/gnutls-3.4.6 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
-    rm -rf gnutls-3.4.10*
-ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.10.
-ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+    rm -rf gnutls-3.4.6*
+ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.6.
+ENV GNUTLS_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 
 # For backward compatibility with older all.sh. At the time of writing,
-# GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
+# GnuTLS 3.4.6 works fine as the "legacy" version, and newer all.sh will
 # stop using a separate GNUTLS_LEGACY_xxx pair of programs.
 ENV GNUTLS_LEGACY_CLI=$GNUTLS_CLI
 ENV GNUTLS_LEGACY_SERV=$GNUTLS_SERV

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -239,8 +239,8 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.6 --exec_prefix=/usr/local/gnutls-3.4.6 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.6*
-ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
-ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+ENV GNUTLS_3_4_6_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_6_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
 ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 # Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.6.

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -172,7 +172,32 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
 # Distro packages tend to include patches that disrupt our testing scripts,
 # and such patches may be added at any time. Avoid surprises by using fixed
 # versions.
-#
+
+# Install openssl 1.0.1j - "legacy" version
+RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
+    tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
+    ./config --openssldir=/usr/local/openssl-1.0.1j && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.0.1j*
+ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
+
+# Install openssl 1.0.2g - main version, in the PATH
+RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
+    tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
+    ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.0.2g*
+ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
+ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
+
+# Install openssl 1.1.1a - "next" version
+RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
+    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
+    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-1.1.1a*
+ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
+
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each
 # version of GnuTLS that we want.
@@ -181,34 +206,6 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
 # - p11-kit: optional, for smart-card support - configure it out
 # - libunistring: since 3.6 - the Ubuntu package works; if it didn't a config
 # option --with-included-libunistring is available.
-
-# Install openssl 1.0.2g - main version, in the PATH
-RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
-    tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
-    ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.0.2g*
-
-ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
-ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
-
-# Install openssl 1.0.1j - "legacy" version
-RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
-    tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
-    ./config --openssldir=/usr/local/openssl-1.0.1j && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.0.1j*
-
-ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
-
-# Install openssl 1.1.1a - "next" version
-RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
-    tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
-    ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
-    make clean && make && make install && cd .. && \
-    rm -rf openssl-1.1.1a*
-
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 # Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
@@ -221,7 +218,6 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.10*
-
 ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
 ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
@@ -243,7 +239,6 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.7.2 --exec_prefix=/usr/local/gnutls-3.7.2 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.7.2*
-
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -173,29 +173,33 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
 # and such patches may be added at any time. Avoid surprises by using fixed
 # versions.
 
-# Install openssl 1.0.1j - "legacy" version
 RUN wget -q https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz && \
     tar -zxf openssl-1.0.1j.tar.gz && cd openssl-1.0.1j && \
     ./config --openssldir=/usr/local/openssl-1.0.1j && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.0.1j*
+ENV OPENSSL_1_0_1=/usr/local/openssl-1.0.1j/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL_LEGACY is 1.0.1j.
 ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
 
-# Install openssl 1.0.2g - main version, in the PATH
 RUN wget -q https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz && \
     tar -zxf openssl-1.0.2g.tar.gz && cd openssl-1.0.2g && \
     ./config --openssldir=/usr/local/openssl-1.0.2g enable-ssl-trace && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.0.2g*
+ENV OPENSSL_1_0_2=/usr/local/openssl-1.0.2g/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL is 1.0.2g.
 ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
-ENV PATH=/usr/local/openssl-1.0.2g/bin:$PATH
 
-# Install openssl 1.1.1a - "next" version
 RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
     tar -zxf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
     ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
     make clean && make && make install && cd .. && \
     rm -rf openssl-1.1.1a*
+ENV OPENSSL_1_1_1=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_1_1=/usr/local/openssl-1.1.1a/bin/openssl
+ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
+# Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
 ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 # GnuTLS has a number of (optional) dependencies:
@@ -218,9 +222,13 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.4.10*
+ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
+ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
+ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.10.
 ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
 
 # For backward compatibility with older all.sh. At the time of writing,
 # GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
@@ -239,6 +247,13 @@ RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \
     ./configure --prefix=/usr/local/gnutls-3.7.2 --exec_prefix=/usr/local/gnutls-3.7.2 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
     rm -rf gnutls-3.7.2*
+ENV GNUTLS_3_7_2_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_7_2_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+ENV GNUTLS_3_7_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_7_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+ENV GNUTLS_3_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_3_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_NEXT_xxx is 3.7.2.
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -228,27 +228,27 @@ ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
 # - libunistring: since 3.6 - the Ubuntu package works; if it didn't a config
 # option --with-included-libunistring is available.
 
-# Install Gnu TLS 3.4.10 (nettle 3.1) - main version, in the PATH
+# Install Gnu TLS 3.4.6 (nettle 3.1) - main version, in the PATH
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz && \
     tar -zxf nettle-3.1.tar.gz && cd nettle-3.1 && \
     ./configure --prefix=/usr/local/libnettle-3.1 --exec_prefix=/usr/local/libnettle-3.1  --disable-shared --disable-openssl && \
     make && make install && cd .. && rm -rf nettle-3.1* && \
     export PKG_CONFIG_PATH=/usr/local/libnettle-3.1/lib/pkgconfig:/usr/local/libnettle-3.1/lib64/pkgconfig:/usr/local/lib/pkgconfig && \
-    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.10.tar.xz && \
-    tar -xJf gnutls-3.4.10.tar.xz && cd gnutls-3.4.10 && \
-    ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 --disable-shared --without-p11-kit && \
+    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.6.tar.xz && \
+    tar -xJf gnutls-3.4.6.tar.xz && cd gnutls-3.4.6 && \
+    ./configure --prefix=/usr/local/gnutls-3.4.6 --exec_prefix=/usr/local/gnutls-3.4.6 --disable-shared --without-p11-kit && \
     make && make install && cat config.log && cd .. && \
-    rm -rf gnutls-3.4.10*
-ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
-# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.10.
-ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
-ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+    rm -rf gnutls-3.4.6*
+ENV GNUTLS_3_4_10_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_10_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+ENV GNUTLS_3_4_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_3_4_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
+# Up to at least 2023, the test scripts expect that $GNUTLS_xxx is 3.4.6.
+ENV GNUTLS_CLI=/usr/local/gnutls-3.4.6/bin/gnutls-cli
+ENV GNUTLS_SERV=/usr/local/gnutls-3.4.6/bin/gnutls-serv
 
 # For backward compatibility with older all.sh. At the time of writing,
-# GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
+# GnuTLS 3.4.6 works fine as the "legacy" version, and newer all.sh will
 # stop using a separate GNUTLS_LEGACY_xxx pair of programs.
 ENV GNUTLS_LEGACY_CLI=$GNUTLS_CLI
 ENV GNUTLS_LEGACY_SERV=$GNUTLS_SERV

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -226,23 +226,11 @@ ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
 ENV PATH=/usr/local/gnutls-3.4.10/bin:$PATH
 
-# Install Gnu TLS 3.3.8 (nettle 2.7) - "legacy" version
-RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz && \
-    tar -zxf nettle-2.7.1.tar.gz && cd nettle-2.7.1 && \
-    # Update autoconf to support building on aarch64
-    cp -f /usr/share/misc/config.sub . && \
-    cp -f /usr/share/misc/config.guess . && \
-    ./configure --prefix=/usr/local/libnettle-2.7.1 --exec_prefix=/usr/local/libnettle-2.7.1  --disable-shared --disable-openssl && \
-    make && make install && cd .. && rm -rf nettle-2.7.1* && \
-    export PKG_CONFIG_PATH=/usr/local/libnettle-2.7.1/lib/pkgconfig:/usr/local/libnettle-2.7.1/lib64/pkgconfig:/usr/local/lib/pkgconfig && \
-    wget -q https://www.gnupg.org/ftp/gcrypt/gnutls/v3.3/gnutls-3.3.8.tar.xz && \
-    tar -xJf gnutls-3.3.8.tar.xz && cd gnutls-3.3.8 && \
-    ./configure --prefix=/usr/local/gnutls-3.3.8 --exec_prefix=/usr/local/gnutls-3.3.8 --disable-shared --without-p11-kit && \
-    make && make install && cat config.log && cd .. && \
-    rm -rf gnutls-3.3.8*
-
-ENV GNUTLS_LEGACY_CLI=/usr/local/gnutls-3.3.8/bin/gnutls-cli
-ENV GNUTLS_LEGACY_SERV=/usr/local/gnutls-3.3.8/bin/gnutls-serv
+# For backward compatibility with older all.sh. At the time of writing,
+# GnuTLS 3.4.10 works fine as the "legacy" version, and newer all.sh will
+# stop using a separate GNUTLS_LEGACY_xxx pair of programs.
+ENV GNUTLS_LEGACY_CLI=$GNUTLS_CLI
+ENV GNUTLS_LEGACY_SERV=$GNUTLS_SERV
 
 # Instal GNU TLS 3.7.2 (nettle 3.7) - "next" version
 RUN wget -q https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz && \

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -202,6 +202,23 @@ ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
 # Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
 ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
+RUN wget -q https://www.openssl.org/source/openssl-3.0.10.tar.gz && \
+    tar -zxf openssl-3.0.10.tar.gz && cd openssl-3.0.10 && \
+    ./config --prefix=/usr/local/openssl-3.0.10 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-3.0.10*
+ENV OPENSSL_3_0_10=/usr/local/openssl-3.0.10/bin/openssl
+ENV OPENSSL_3_0=/usr/local/openssl-3.0.10/bin/openssl
+
+RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
+    tar -zxf openssl-3.1.2.tar.gz && cd openssl-3.1.2 && \
+    ./config --prefix=/usr/local/openssl-3.1.2 -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' enable-ssl-trace && \
+    make clean && make && make install && cd .. && \
+    rm -rf openssl-3.1.2*
+ENV OPENSSL_3_1_2=/usr/local/openssl-3.1.2/bin/openssl
+ENV OPENSSL_3_1=/usr/local/openssl-3.1.2/bin/openssl
+ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
+
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each
 # version of GnuTLS that we want.


### PR DESCRIPTION
Start using version numbers in $OPENSSL and $GNUTLS variables, e.g. `$OPENSSL_1`, `$OPENSSL_1_1` and `$OPENSSL_1_1_1` are OpenSSL 1.1.1a. This will allow `all.sh` to reference these versions.

Keep the old names `$OPENSSL_NEXT` etc. pointing to the same versions for backward compatibility: we don't want to break `all.sh` in branches of mbedtls we care about (`development`, `mbedtls-2.28`, as well as open pull requests to these branches and other work in progress). We won't change what these non-numbered variables point to, we'll gradually migrate away from them.

Remove GnuTLS 3.3.8 which was `GNUTLS_LEGACY` and replace GnuTLS 3.4.10 with 3.4.6 which has all the features we need and [one less bugfix](https://github.com/Mbed-TLS/mbedtls-test/pull/122/commits/46a206feb6a0ab89e70c87599dcc642ee4f05f8d)). See also [3.x](https://github.com/Mbed-TLS/mbedtls/pull/8121), [2.28](https://github.com/Mbed-TLS/mbedtls/pull/8122) removing the use of `GNUTLS_LEGACY`.

Add OpenSSL 3.0 (long-time support branch) and 3.1 (latest release at this time) so that we can [test with modern versions of OpenSSL](https://github.com/Mbed-TLS/mbedtls/issues/7350). (Newer GnuTLS may follow later.)

### Test runs

* 46a206feb6a0ab89e70c87599dcc642ee4f05f8d on `development`: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/530/ → (a previous run almost passed but glitched during result analysis)
* 46a206feb6a0ab89e70c87599dcc642ee4f05f8d on `mbedtls-2.28`: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/529/ → PASS
* 46a206feb6a0ab89e70c87599dcc642ee4f05f8d on https://github.com/Mbed-TLS/mbedtls/pull/8122 : https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/51/ → PASS
* 20fcf5d6e3d007c7fb57b9696be9c2dae64f6af1 on development: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/55/ → 
* a455488a4200febdd5c22b5f8f7dc2eaadbebe07 on `development`: [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/91/) → PASS
* a455488a4200febdd5c22b5f8f7dc2eaadbebe07 on `mbedtls-2.28`: [Internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/543/) → PASS
