### PR TITLE
Add mechanism to override Python requirements

### DIFF
--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -76,6 +76,13 @@ RUN apt-get update -q && apt-get install -yq \
 # The pip wrapper scripts can get out of sync with pip due to upgrading it
 # outside the package manager, so invoke the module directly.
 RUN python3 -m pip config set global.progress_bar off && \
+    # Ubuntu 20.04 ships pip 20.0.2. We want the ability to specify both
+    # a versioned requirement and an unversioned requirement for the
+    # same package (e.g. `pip install foo bar foo==42`), and this is
+    # only possible since pip 20.3. So upgrade pip to the latest
+    # release at the time of writing (use a fixed version to avoid
+    # surprises when rebuilding the image).
+    python3 -m pip install 'pip==23.2.1' && \
     python3 -m pip install setuptools --upgrade && \
     true
 

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -255,6 +255,13 @@ RUN git clone --branch uncrustify-0.75.1 https://github.com/uncrustify/uncrustif
 # The pip wrapper scripts can get out of sync with pip due to upgrading it
 # outside the package manager, so invoke the module directly.
 RUN python3 -m pip config set global.progress_bar off && \
+    # Ubuntu 20.04 ships pip 20.0.2. We want the ability to specify both
+    # a versioned requirement and an unversioned requirement for the
+    # same package (e.g. `pip install foo bar foo==42`), and this is
+    # only possible since pip 20.3. So upgrade pip to the latest
+    # release at the time of writing (use a fixed version to avoid
+    # surprises when rebuilding the image).
+    python3 -m pip install 'pip==23.2.1' && \
     python3 -m pip install setuptools --upgrade && \
     true
 

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -70,10 +70,6 @@ import hudson.AbortException
  * and bare python on other platforms. */
 @Field has_min_requirements = null
 
-/* We need to know whether the code is C99 in order to decide which versions
- * of Visual Studio to test with: older versions lack C99 support. */
-@Field code_is_c99 = null
-
 @Field freebsd_all_sh_components = [
     /* Do not include any components that do TLS system testing, because
      * we don't maintain suitable versions of OpenSSL and GnuTLS on

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -287,7 +287,8 @@ def gen_abi_api_checking_job(platform) {
             deleteDir()
             common.get_docker_image(platform)
             dir('src') {
-                checkout_repo.checkout_repo()
+                BranchInfo info = common.get_branch_information()
+                checkout_repo.checkout_repo(info)
                 /* The credentials here are the SSH credentials for accessing the repositories.
                    They are defined at {JENKINS_URL}/credentials */
                 withCredentials([sshUserPrivateKey(credentialsId: credentials_id, keyFileVariable: 'keyfile')]) {

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -96,8 +96,8 @@ def run_pr_job(is_production=true) {
             common.init_docker_images()
 
             stage('pre-test-checks') {
-                common.get_branch_information()
-                common.check_every_all_sh_component_will_be_run()
+                info = common.get_branch_information()
+                common.check_every_all_sh_component_will_be_run(info)
             }
         } catch (err) {
             def description = 'Pre-test checks failed.'

--- a/vars/scripts.groovy
+++ b/vars/scripts.groovy
@@ -19,8 +19,7 @@
 
 import groovy.transform.Field
 
-@Field static final String win32_mingw_test_bat = '''\
-if exist scripts\\min_requirements.py python scripts\\min_requirements.py || exit
+@Field static final String win32_mingw_test_bat = """\
 set CC=gcc
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "MinGW Makefiles" || exit
@@ -28,33 +27,30 @@ mingw32-make || exit
 mingw32-make test || exit
 ctest -VV || exit
 programs\\test\\selftest.exe || exit
-'''
+"""
 
-@Field static final String iar8_mingw_test_bat = '''\
-if exist scripts\\min_requirements.py python scripts\\min_requirements.py || exit
+@Field static final String iar8_mingw_test_bat = """\
 set CC=iccarm
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 perl scripts/config.pl baremetal || exit
 cmake -D CMAKE_BUILD_TYPE:String=Check -G "MinGW Makefiles" . || exit
 mingw32-make lib || exit
-'''
+"""
 
-@Field static final String win32_msvc12_32_test_bat = '''\
-if exist scripts\\min_requirements.py python scripts\\min_requirements.py || exit
+@Field static final String win32_msvc12_32_test_bat = """\
 call "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 12" || exit
 MSBuild ALL_BUILD.vcxproj || exit
 programs\\test\\Debug\\selftest.exe || exit
-'''
+"""
 
-@Field static final String win32_msvc12_64_test_bat = '''\
-if exist scripts\\min_requirements.py python scripts\\min_requirements.py || exit
+@Field static final String win32_msvc12_64_test_bat = """\
 call "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 12 Win64" || exit
 MSBuild ALL_BUILD.vcxproj || exit
 programs\\test\\Debug\\selftest.exe || exit
-'''
+"""

--- a/vars/scripts.groovy
+++ b/vars/scripts.groovy
@@ -19,7 +19,7 @@
 
 import groovy.transform.Field
 
-@Field static final String win32_mingw_test_bat = """\
+@Field static final String win32_mingw_test_bat = '''\
 set CC=gcc
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "MinGW Makefiles" || exit
@@ -27,30 +27,30 @@ mingw32-make || exit
 mingw32-make test || exit
 ctest -VV || exit
 programs\\test\\selftest.exe || exit
-"""
+'''
 
-@Field static final String iar8_mingw_test_bat = """\
+@Field static final String iar8_mingw_test_bat = '''\
 set CC=iccarm
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 perl scripts/config.pl baremetal || exit
 cmake -D CMAKE_BUILD_TYPE:String=Check -G "MinGW Makefiles" . || exit
 mingw32-make lib || exit
-"""
+'''
 
-@Field static final String win32_msvc12_32_test_bat = """\
+@Field static final String win32_msvc12_32_test_bat = '''\
 call "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 12" || exit
 MSBuild ALL_BUILD.vcxproj || exit
 programs\\test\\Debug\\selftest.exe || exit
-"""
+'''
 
-@Field static final String win32_msvc12_64_test_bat = """\
+@Field static final String win32_msvc12_64_test_bat = '''\
 call "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 12 Win64" || exit
 MSBuild ALL_BUILD.vcxproj || exit
 programs\\test\\Debug\\selftest.exe || exit
-"""
+'''


### PR DESCRIPTION
Use it to hotfix https://github.com/Mbed-TLS/mbedtls/pull/8250 on branches forked before https://github.com/Mbed-TLS/mbedtls/pull/8249. That is, with this pull request, we can run the CI on older branches whose `jsonschema` dependency breaks our CI.

Status: ready if this passes CI (currently not expecting failures except maybe abi-api-check).

CI runs on 90a27efd6903499db93cf1c003d89cfecc675b4b or 13061ca754d15dbe59a9aef86acf1d4554d82fd3 (they have identical contents):

* `development` before #8249, [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/83/) → pass, with `override.requirements.txt` attached
* `development` after #8249, [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/84/) → pass, with no requirements override
* `mbedtls-2.28`, [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/85/), with no requirements override: pass, with no requirements override
* `development` before #8249, [Internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/540/): pass
* abi-api-check, [OpenCI](https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/18/) → fail

CI runs on 6eeeffcbff883b8e952b0c8bc8c56f13752baff6 (changes only on Windows and abi-api-check):

* `development` before #8249, [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/88/) → pass
* abi-api-check, [OpenCI](https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/19/) → ok (ran normally, reported some problems but that is to be expected because the two branches I used have API differences and the test job does not merge the target branch)
