### PR TITLE
Copy the Arm compilers from a fixed base image

### DIFF
--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -74,16 +74,6 @@ RUN apt-get update -q && apt-get install -yq \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/
 
-# Install ARM Compiler 5.06 and 6.6
-COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_5.06u3 /usr/local/ARM_Compiler_5.06u3
-COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_6.6 /usr/local/ARM_Compiler_6.6
-
-ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
-ENV ARMC6_BIN_DIR=/usr/local/ARM_Compiler_6.6/bin/
-ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
-ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56
-ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
-
 # Install Python pip packages
 #
 # The pip wrapper scripts can get out of sync with pip due to upgrading it
@@ -96,6 +86,16 @@ RUN python3 -m pip config set global.progress_bar off && \
 RUN locale && \
     locale-gen "en_US.UTF-8" && \
     dpkg-reconfigure locales
+
+# Install ARM Compiler 5.06 and 6.6
+COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_5.06u3 /usr/local/ARM_Compiler_5.06u3
+COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_6.6 /usr/local/ARM_Compiler_6.6
+
+ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
+ENV ARMC6_BIN_DIR=/usr/local/ARM_Compiler_6.6/bin/
+ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
+ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56
+ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
 # Add user
 RUN useradd -m user

--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -29,10 +29,12 @@
 # ARMLMD_LICENSE_FILE argument when building the image
 # (docker build --build-arg ARMLMD_LICENSE_FILE=... arm-compilers).
 
-# For now, use a fixed base version which is present in our image caches.
+# For now, copy the ARM compilers from a fixed image which is present in our caches.
 # This avoids the problem that the download URLs for Arm compilers are
 # not longer valid.
-FROM ubuntu:focal-20221019
+FROM trustedfirmware/ci-amd64-mbed-tls-ubuntu:arm-compilers-c568d022eecd6e6263f7bc0f8e94e003dd652160 AS arm-compiler-binaries
+
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /opt/src
@@ -50,110 +52,37 @@ RUN dpkg --add-architecture i386
 # handled below. One big alphabetised list, in order to avoid duplicates, with
 # comments explaining why each package is needed.
 RUN apt-get update -q && apt-get install -yq \
-        # for Mbed TLS tests
-        abi-compliance-checker \
-        # Note that there is a known issue #5332 that stock abi tools
-        # in ubuntu20.04 do not fail as expected. 
-        # https://github.com/ARMmbed/mbedtls/issues/5332
-        # Do not activae 20.04 until that is resolved
-        # to use with abi-compliance-tester
-        abi-dumper \
         # to build Mbed TLS: gcc, binutils, make, etc.
         build-essential \
         # to build Mbed TLS
-        clang \
-        # to build Mbed TLS
         cmake \
-        # to build Mbed TLS's documentation
-        doxygen \
-        # to cross-build Mbed TLS
-        gcc-mingw-w64-i686 \
         # to check out Mbed TLS and others
         git \
-        # to build Mbed TLS's documentation
-        graphviz \
-        # to measure code coverage of Mbed TLS
-        lcov \
         # for 32-bit Mbed TLS testing and armcc
         libc6-i386 \
         # for 32-bit Mbed TLS testing and armcc
         libc6:i386 \
-        # to build GnuTLS (nettle with public key support aka hogweed)
-        libgmp-dev \
-        # to build GnuTLS >= 3.6 (could also use --with-included-unistring)
-        libunistring-dev \
         # for armcc
         libstdc++6:i386 \
-        # to build GnuTLS
-        libtasn1-6-dev \
         # needed for armcc (see locale-gen below)
         locales \
-        # used by compat.sh and ssl-opt.sh
-        lsof \
-        # to build GnuTLS (nettle)
-        m4 \
-        # to build Mbed TLS and others
-        make \
-        # to build GnuTLS with locally-compiled nettle
-        pkg-config \
         # to install several Python packages (done by individual jobs)
         python3-pip \
-        # for Mbed TLS tests
-        valgrind \
-        # to download things installed from other places
-        wget \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g \
         # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/
 
-# Install all the parts of gcc-multilib, which is necessary for 32-bit builds.
-# gcc-multilib conflicts with cross-compiler packages that we'll install later,
-# so don't keep it around. Just let it install its dependencies
-# (gcc-<VERSION>-multilib and libc support), then remove it. Manually create
-# one crucial symlink that's otherwise provided by the gcc-multilib package
-# (without that symlink, 32-bit builds won't find system headers). Note that
-# just installing the dependencies of gcc-multilib also brings in gcc-multilib
-# as a Recommends dependency.
-RUN apt-get update -q && apt-get install -yq \
-        gcc-multilib \
-    && rm -rf /var/lib/apt/lists/ && \
-    dpkg -r gcc-multilib && \
-    ln -s x86_64-linux-gnu/asm /usr/include/asm
-
-# Install arm-linux-gnueabi-gcc - to cross-build Mbed TLS
-RUN apt-get update -q && apt-get install -yq \
-        gcc-arm-linux-gnueabi \
-        libc6-dev-armel-cross \
-    && rm -rf /var/lib/apt/lists/
-
-# Install ARM Compiler 5.06
-RUN wget -q https://armkeil.blob.core.windows.net/developer/Files/downloads/compiler/DS500-PA-00003-r5p0-22rel0.tgz && \
-    tar -zxf DS500-PA-00003-r5p0-22rel0.tgz && \
-    ./Installer/setup.sh --i-agree-to-the-contained-eula --no-interactive -d /usr/local/ARM_Compiler_5.06u3 --quiet && \
-    rm -rf DS500-PA-00003-r5p0-22rel0.tgz releasenotes.html Installer/
+# Install ARM Compiler 5.06 and 6.6
+COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_5.06u3 /usr/local/ARM_Compiler_5.06u3
+COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_6.6 /usr/local/ARM_Compiler_6.6
 
 ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
+ENV ARMC6_BIN_DIR=/usr/local/ARM_Compiler_6.6/bin/
 ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
 ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
-
-# Install ARM Compiler 6.6
-RUN mkdir temp && cd temp && \
-    wget -q --no-check-certificate https://armkeil.blob.core.windows.net/developer//sitecore/shell/-/media/Files/downloads/compiler/DS500-BN-00026-r5p0-07rel0.tgz -O arm6.tgz && \
-    tar -zxf arm6.tgz  && ls -ltr && \
-    ./install_x86_64.sh --i-agree-to-the-contained-eula --no-interactive -d /usr/local/ARM_Compiler_6.6 --quiet && \
-    cd .. && rm -rf temp/
-
-ENV ARMC6_BIN_DIR=/usr/local/ARM_Compiler_6.6/bin/
-
-# Install arm-none-eabi-gcc
-RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/5_4-2016q3/gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2 -O gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2 && \
-    tar -xjf gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2 -C /opt && \
-    rm gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2
-
-ENV PATH=/opt/gcc-arm-none-eabi-5_4-2016q3/bin:$PATH
 
 # Install Python pip packages
 #

--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -32,7 +32,8 @@
 # For now, copy the ARM compilers from a fixed image which is present in our caches.
 # This avoids the problem that the download URLs for Arm compilers are
 # not longer valid.
-FROM trustedfirmware/ci-amd64-mbed-tls-ubuntu:arm-compilers-c568d022eecd6e6263f7bc0f8e94e003dd652160 AS arm-compiler-binaries
+ARG DOCKER_REPO
+FROM $DOCKER_REPO:arm-compilers-c568d022eecd6e6263f7bc0f8e94e003dd652160 AS arm-compiler-binaries
 
 FROM ubuntu:20.04
 

--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -69,10 +69,6 @@ RUN apt-get update -q && apt-get install -yq \
         locales \
         # to install several Python packages (done by individual jobs)
         python3-pip \
-        # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
-        zlib1g \
-        # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
-        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/
 
 # Install Python pip packages

--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+#
 # arm-compilers/Dockerfile
 #
 #  Copyright (c) 2018-2022, ARM Limited, All Rights Reserved

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -617,15 +617,6 @@ aws ecr get-login-password | docker login --username AWS --password-stdin $commo
 """
                         }
 
-                        /* Hack alert: at the time of writing, building the
-                         * arm-compilers image doesn't work, because the
-                         * URLS to download Arm compilers aren't valid anymore.
-                         * So arrange to look for cached copies of the image.
-                         */
-                        if (platform == 'arm-compilers') {
-                            extra_build_args += " --cache-from $common.docker_repo:ubuntu-20.04-f15359b0ac46e767133991b76ccf23e3cd2e5e0f "
-                        }
-
                         analysis.record_inner_timestamps('dockerfile-builder', platform) {
                             sh """\
 # Use BuildKit and a remote build cache to pull only the reuseable layers

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -623,6 +623,7 @@ aws ecr get-login-password | docker login --username AWS --password-stdin $commo
 # from the last successful build for this platform
 DOCKER_BUILDKIT=1 docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --build-arg DOCKER_REPO=$common.docker_repo \
     $extra_build_args \
     --cache-from $common.docker_repo:$platform-cache \
     -t $common.docker_repo:$tag \


### PR DESCRIPTION
This lets us refactor the arm-compilers Dockerfile, and circumvents any issues with changes to Docker's layer caching behaviour.

Test runs:
  - [Internal CI][1]
  - [OpenCI][2]
  
[1]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/538/
[2]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/82/