### PR TITLE
Restrict automatic runs of PR jobs

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -34,6 +34,7 @@ import groovy.transform.Field
 import com.cloudbees.groovy.cps.NonCPS
 import hudson.AbortException
 import org.jenkinsci.plugins.github_branch_source.Connector
+import org.kohsuke.github.GHPermissionType
 
 /* Indicates if CI is running on Open CI (hosted on https://ci.trustedfirmware.org/) */
 @Field is_open_ci_env = env.JENKINS_URL ==~ /\S+(trustedfirmware)\S+/
@@ -438,9 +439,9 @@ Logs: ${env.BUILD_URL}
 }
 
 @NonCPS
-boolean is_pr_author_member_of_team(String repo, int pr) {
+boolean pr_author_has_write_access(String repo_name, int pr) {
     String credentials = is_open_ci_env ? 'mbedtls-github-token' : 'd015f9b1-4800-4a81-86b3-9dbadc18ee00'
     def github = Connector.connect(null, Connector.lookupScanCredentials(currentBuild.rawBuild.parent, null, credentials))
-    def author = github.getRepository(repo).getPullRequest(pr).user
-    return github.getOrganization('Mbed-TLS').getTeamBySlug('mbed-tls-reviewers').hasMember(author)
+    def repo = github.getRepository(repo_name)
+    return repo.getPermission(repo.getPullRequest(pr).user) in [GHPermissionType.ADMIN, GHPermissionType.WRITE]
 }

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -33,6 +33,7 @@ import groovy.transform.Field
 
 import com.cloudbees.groovy.cps.NonCPS
 import hudson.AbortException
+import org.jenkinsci.plugins.github_branch_source.Connector
 
 /* Indicates if CI is running on Open CI (hosted on https://ci.trustedfirmware.org/) */
 @Field is_open_ci_env = env.JENKINS_URL ==~ /\S+(trustedfirmware)\S+/
@@ -434,4 +435,12 @@ Logs: ${env.BUILD_URL}
              subject: subject,
              to: recipients,
              mimeType: 'text/plain'
+}
+
+@NonCPS
+boolean is_pr_author_member_of_team(String repo, int pr) {
+    String credentials = is_open_ci_env ? 'mbedtls-github-token' : 'd015f9b1-4800-4a81-86b3-9dbadc18ee00'
+    def github = Connector.connect(null, Connector.lookupScanCredentials(currentBuild.rawBuild.parent, null, credentials))
+    def author = github.getRepository(repo).getPullRequest(pr).user
+    return github.getOrganization('Mbed-TLS').getTeamBySlug('mbed-tls-reviewers').hasMember(author)
 }

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -86,7 +86,7 @@ def run_pr_job(is_production=true) {
         boolean is_merge_queue = env.BRANCH_NAME ==~ /gh-readonly-queue\/.*/
 
         if (!is_merge_queue && currentBuild.rawBuild.getCause(Cause.UserIdCause) == null) {
-            if (!common.is_pr_author_member_of_team("$env.GITHUB_ORG/$env.GITHUB_REPO", env.CHANGE_ID as int)) {
+            if (!common.pr_author_has_write_access("$env.GITHUB_ORG/$env.GITHUB_REPO", env.CHANGE_ID as int)) {
                 echo 'PR author not found on allowlist - not building'
                 throw new FlowInterruptedException(Result.NOT_BUILT, new CauseOfInterruption[0])
             }


### PR DESCRIPTION
Only run PR job if one of the following is true:
- The author of the PR has write access to the repo the PR is targeting
- The job is triggered by the Github merge queue (thus the PR has been reviewed by a gatekeeper)
- The job was started manually from the Jenkins UI

Test runs:
- Push to a PR authored by a non-member (PR-merge):
  - [Internal CI][1]
  - [OpenCI][2]
- Manual run of a PR by a non-member (PR-merge):
  - [Internal CI][3]
  - [OpenCI][4]
- Manual run of a PR with an expected failure (PR-head):
  - [Internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-759-head/23/)
- Push to a PR authored by a team-member (PR-head).
  - [Internal CI][5]
  - [OpenCI][6]

[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-806-merge/26/
[2]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-806-merge/26/
[3]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-806-merge/27/ 
[4]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-806-merge/27/
[5]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-head/83/
[6]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/10/