### PR TITLE
Prevent deadlock in api-abi-checking job

### DIFF
--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -281,13 +281,13 @@ def gen_windows_jobs(BranchInfo info, String label_prefix='') {
 def gen_abi_api_checking_job(platform) {
     def job_name = 'ABI-API-checking'
     def credentials_id = common.is_open_ci_env ? "mbedtls-github-ssh" : "742b7080-e1cc-41c6-bf55-efb72013bc28"
+    BranchInfo info = common.get_branch_information()
 
     return instrumented_node_job('container-host', job_name) {
         try {
             deleteDir()
             common.get_docker_image(platform)
             dir('src') {
-                BranchInfo info = common.get_branch_information()
                 checkout_repo.checkout_repo(info)
                 /* The credentials here are the SSH credentials for accessing the repositories.
                    They are defined at {JENKINS_URL}/credentials */


### PR DESCRIPTION
Calling `get_branch_information()` inside an `instrumented_node_job()` block causes the nesting of two `node()` blocks. This makes the script wait for a new node to be allocated on an executor, while still occpying the original executor as well. This slows the CI down considerably, and causes a deadlock if all nodes are occupied by api-abi checking jobs waiting for a node to be allocated.

Test runs:
- [Internal CI][1]
- [Open CI][2]

[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-merge/131/
[2]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-merge/10/