### PR TITLE
Restore logic for tests skipped in merge queue

### DIFF
--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -95,7 +95,7 @@ def run_pr_job(is_production=true) {
         try {
             common.maybe_notify_github('PENDING', 'In progress')
 
-            if (!is_merge_queue) {
+            if (!common.is_open_ci_env && is_merge_queue) {
                 // Fake required checks that don't run in the merge queue
                 def skipped_checks = [
                     'DCO',


### PR DESCRIPTION
The logic for faking tests that are required for but do not run when testing a PR in the merge queue was broken in #129.

This PR restores the logic that was used prior to that PR.

CI runs:
- [Merge queue run][1] before this PR on Mbed-TLS/mbedtls#8328
- [Merge queue run][2] with this PR on Mbed-TLS/mbedtls#7959

(The test commit in Mbed-TLS/mbedtls#7959 states that it introduces a conflict with the base branch, but to expedite testing this PR it was repurposed and the conflict was removed from the base branch. The expected result for its merge queue run is SUCCESS.)

[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-head/job/gh-readonly-queue%252Fdevelopment%252Fpr-8328-e7ebec6723b61bd54800f649b1391e980edf2fbd/1/
[2]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/job/gh-readonly-queue%252Fdev%252Fbensze01%252Fmerge-queue-test%252Fpr-7959-e7ebec6723b61bd54800f649b1391e980edf2fbd/2/