### PR TITLE
Install the armhf and aarch64 gcc-cross toolchains

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -137,18 +137,26 @@ RUN if [ "$(uname -m)" = x86_64 ]; then \
         ln -s x86_64-linux-gnu/asm /usr/include/asm; \
     fi
 
-# Install arm-linux-gnueabi-gcc and arm-none-eabi-gcc - to cross-build Mbed TLS
+# Install the Arm gcc-cross toolchains
 RUN apt-get update -q && apt-get install -yq \
         gcc-arm-linux-gnueabi \
+        gcc-arm-linux-gnueabihf \
         gcc-arm-none-eabi \
+        libc6-dev-arm64-cross \
         libc6-dev-armel-cross \
-    && rm -rf /var/lib/apt/lists/ && \
+        libc6-dev-armhf-cross \
+    && \
     if [ "$(uname -m)" = aarch64 ]; then \
         # HACK: Ubuntu doesn't provide an armel port for Thumb-1 testing, so link
         #       the cross-compiler's libraries into the standard multiarch location.
         ln -s /usr/arm-linux-gnueabi/lib /lib/arm-linux-gnueabi && \
         ln -s arm-linux-gnueabi/ld-linux.so.3 /lib/ld-linux.so.3; \
-    fi
+    else  \
+        # The gcc-aarch64-linux-gnu virtual package doesn't exist on AArch64 Ubuntu < 20.04
+        apt-get install -yq  \
+            gcc-aarch64-linux-gnu \
+        ; \
+    fi && rm -rf /var/lib/apt/lists/
 
 # Install exact upstream versions of OpenSSL and GnuTLS
 #

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -130,18 +130,26 @@ RUN if [ "$(uname -m)" = x86_64 ]; then \
         ln -s x86_64-linux-gnu/asm /usr/include/asm; \
     fi
 
-# Install arm-linux-gnueabi-gcc and arm-none-eabi-gcc - to cross-build Mbed TLS
+# Install the Arm gcc-cross toolchains
 RUN apt-get update -q && apt-get install -yq \
         gcc-arm-linux-gnueabi \
+        gcc-arm-linux-gnueabihf \
         gcc-arm-none-eabi \
+        libc6-dev-arm64-cross \
         libc6-dev-armel-cross \
-    && rm -rf /var/lib/apt/lists/ && \
+        libc6-dev-armhf-cross \
+    && \
     if [ "$(uname -m)" = aarch64 ]; then \
         # HACK: Ubuntu doesn't provide an armel port for Thumb-1 testing, so link
         #       the cross-compiler's libraries into the standard multiarch location.
         ln -s /usr/arm-linux-gnueabi/lib /lib/arm-linux-gnueabi && \
         ln -s arm-linux-gnueabi/ld-linux.so.3 /lib/ld-linux.so.3; \
-    fi
+    else  \
+        # The gcc-aarch64-linux-gnu virtual package doesn't exist on AArch64 Ubuntu < 20.04
+        apt-get install -yq  \
+            gcc-aarch64-linux-gnu \
+        ; \
+    fi && rm -rf /var/lib/apt/lists/
 
 # Install abi-compliance-checker
 # The version in Ubuntu 18.04 is too old, we want at least the version below

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -136,7 +136,7 @@ RUN if [ "$(uname -m)" = x86_64 ]; then \
         ln -s x86_64-linux-gnu/asm /usr/include/asm; \
     fi
 
-# Install arm-linux-gnueabi-gcc and arm-none-eabi-gcc - to cross-build Mbed TLS
+# Install the Arm gcc-cross toolchains
 RUN if [ "$(uname -m)" = aarch64 ]; then \
         # HACK: Ubuntu doesn't provide an armel port for Thumb-1 testing, so link
         #       the cross-compiler's libraries into the standard multiarch location.
@@ -147,9 +147,13 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
         ln -s arm-linux-gnueabi/ld-linux.so.3 /lib/ld-linux.so.3; \
     fi && \
     apt-get update -q && apt-get install -yq \
+        gcc-aarch64-linux-gnu \
         gcc-arm-linux-gnueabi \
+        gcc-arm-linux-gnueabihf \
         gcc-arm-none-eabi \
+        libc6-dev-arm64-cross \
         libc6-dev-armel-cross \
+        libc6-dev-armhf-cross \
     && rm -rf /var/lib/apt/lists/
 
 # Install exact upstream versions of OpenSSL and GnuTLS

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -151,7 +151,7 @@ RUN if [ "$(uname -m)" = x86_64 ]; then \
         ln -s x86_64-linux-gnu/asm /usr/include/asm; \
     fi
 
-# Install arm-linux-gnueabi-gcc and arm-none-eabi-gcc - to cross-build Mbed TLS
+# Install the Arm gcc-cross toolchains
 RUN if [ "$(uname -m)" = aarch64 ]; then \
         # HACK: Ubuntu doesn't provide an armel port for Thumb-1 testing, so link
         #       the cross-compiler's libraries into the standard multiarch location.
@@ -162,9 +162,13 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
         ln -s arm-linux-gnueabi/ld-linux.so.3 /lib/ld-linux.so.3; \
     fi && \
     apt-get update -q && apt-get install -yq \
+        gcc-aarch64-linux-gnu \
         gcc-arm-linux-gnueabi \
+        gcc-arm-linux-gnueabihf \
         gcc-arm-none-eabi \
+        libc6-dev-arm64-cross \
         libc6-dev-armel-cross \
+        libc6-dev-armhf-cross \
     && rm -rf /var/lib/apt/lists/
 
 # Install exact upstream versions of OpenSSL and GnuTLS


### PR DESCRIPTION
This lets us test building the library with the arm cryptographic extensions.

Builds:
- Ubuntu 16.04 and 20.04
  - [Internal CI][1]
  - [OpenCI][2]
- Ubuntu 20.04 and 22.04
  - [Internal CI][3]
  - [OpenCI][4]
  
[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/303/
[2]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/22/
[3]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/301/
[4]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/20/