### PR TITLE
Flip the merge queue to OpenCI

### DIFF
--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -99,7 +99,7 @@ def run_pr_job(is_production=true) {
         try {
             common.maybe_notify_github('PENDING', 'In progress')
 
-            if (!common.is_open_ci_env && is_merge_queue) {
+            if (common.is_open_ci_env && is_merge_queue) {
                 // Fake required checks that don't run in the merge queue
                 def skipped_checks = [
                     'DCO',


### PR DESCRIPTION
We've switched again to making OpenCI the required CI, which runs on the merge queue. So we need to make OpenCI fake the status checks.

This is a minimal emergency fix. I've filed https://github.com/Mbed-TLS/mbedtls-test/issues/139 for more robustness.