### PR TITLE
Fix windows_testing.py hanging at command prompt

### DIFF
--- a/resources/windows/windows_testing.py
+++ b/resources/windows/windows_testing.py
@@ -459,7 +459,7 @@ class MbedWindowsTesting(object):
             return False
 
         cmd = (
-            'call {} {} && '
+            'call "{}" "{}" && '
             'msbuild /nodeReuse:false /t:Rebuild /p:Configuration={},Platform={},PlatformToolset={} /m "{}"'
             ).format(
                 self.visual_studio_vcvars_path[test_run.vs_version],

--- a/resources/windows/windows_testing.py
+++ b/resources/windows/windows_testing.py
@@ -394,7 +394,7 @@ class MbedWindowsTesting(object):
             solution_dir
         )
         my_environment["CTEST_OUTPUT_ON_FAILURE"] = "1"
-        cmd = 'call "{}" "{}" && msbuild /nodeReuse:false /p:Configuration={} /m RUN_TESTS.vcxproj'.format(
+        cmd = 'call "{}" {} && msbuild /nodeReuse:false /p:Configuration={} /m RUN_TESTS.vcxproj'.format(
             self.visual_studio_vcvars_path[test_run.vs_version],
             self.visual_studio_architecture_flags[test_run.architecture],
             test_run.configuration
@@ -459,7 +459,7 @@ class MbedWindowsTesting(object):
             return False
 
         cmd = (
-            'call "{}" "{}" && '
+            'call "{}" {} && '
             'msbuild /nodeReuse:false /t:Rebuild /p:Configuration={},Platform={},PlatformToolset={} /m "{}"'
             ).format(
                 self.visual_studio_vcvars_path[test_run.vs_version],

--- a/resources/windows/windows_testing.py
+++ b/resources/windows/windows_testing.py
@@ -460,7 +460,7 @@ class MbedWindowsTesting(object):
 
         cmd = (
             'call {} {} && '
-            'msbuild /nodeReuse:false /t:Rebuild /p:Configuration={},Platform={}, PlatformToolset={} /m "{}"'
+            'msbuild /nodeReuse:false /t:Rebuild /p:Configuration={},Platform={},PlatformToolset={} /m "{}"'
             ).format(
                 self.visual_studio_vcvars_path[test_run.vs_version],
                 self.visual_studio_architecture_flags[test_run.architecture],

--- a/resources/windows/windows_testing.py
+++ b/resources/windows/windows_testing.py
@@ -394,25 +394,19 @@ class MbedWindowsTesting(object):
             solution_dir
         )
         my_environment["CTEST_OUTPUT_ON_FAILURE"] = "1"
+        cmd = 'call "{}" "{}" && msbuild /nodeReuse:false /p:Configuration={} /m RUN_TESTS.vcxproj'.format(
+            self.visual_studio_vcvars_path[test_run.vs_version],
+            self.visual_studio_architecture_flags[test_run.architecture],
+            test_run.configuration
+        )
         msbuild_test_process = subprocess.Popen(
-            ["cmd.exe"],
+            cmd, shell=True,
             env=my_environment,
             encoding=sys.stdout.encoding,
             cwd=solution_dir,
-            stdin=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
         )
-        msbuild_test_process.stdin.write("\"{}\" {}\n".format(
-            self.visual_studio_vcvars_path[test_run.vs_version],
-            self.visual_studio_architecture_flags[test_run.architecture]
-        ))
-        msbuild_test_process.stdin.write(
-            "msbuild /nodeReuse:false /p:Configuration={} /m RUN_TESTS.vcxproj\n".format(
-                test_run.configuration
-            )
-        )
-        msbuild_test_process.stdin.close()
         msbuild_test_output, _ = msbuild_test_process.communicate()
         logger.info(msbuild_test_output)
         if (msbuild_test_process.returncode == 0 and
@@ -463,27 +457,24 @@ class MbedWindowsTesting(object):
             self.set_return_code(1)
             test_run.results[solution_type + " build"] = "Fail"
             return False
-        msbuild_process = subprocess.Popen(
-            ["cmd.exe"],
-            env=my_environment,
-            encoding=sys.stdout.encoding,
-            cwd=solution_dir,
-            stdin=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdout=subprocess.PIPE,
-        )
-        msbuild_process.stdin.write("\"{}\" {}\n".format(
-            self.visual_studio_vcvars_path[test_run.vs_version],
-            self.visual_studio_architecture_flags[test_run.architecture]
-        ))
-        msbuild_process.stdin.write(
-            "msbuild /nodeReuse:false /t:Rebuild /p:Configuration={},Platform={},"
-            "PlatformToolset={} /m \"{}\"\n".format(
+
+        cmd = (
+            'call {} {} && '
+            'msbuild /nodeReuse:false /t:Rebuild /p:Configuration={},Platform={}, PlatformToolset={} /m "{}"'
+            ).format(
+                self.visual_studio_vcvars_path[test_run.vs_version],
+                self.visual_studio_architecture_flags[test_run.architecture],
                 test_run.configuration, test_run.architecture,
                 retarget, solution_file
             )
+        msbuild_process = subprocess.Popen(
+            cmd, shell=True,
+            env=my_environment,
+            encoding=sys.stdout.encoding,
+            cwd=solution_dir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
         )
-        msbuild_process.stdin.close()
         msbuild_output, _ = msbuild_process.communicate()
         logger.info(msbuild_output)
         if (msbuild_process.returncode == 0 and


### PR DESCRIPTION
The script sometimes hangs at the command prompt, waiting for more input after the tests complete.
Switch to passing the commands to the shell during process creation, instead of piping them in after the fact.

This patch is submitted separately to ease reviews. Further clean-up of `windows_testing.py` will follow in a separate PR.

Test runs (c50e95d):
- Internal CI:
  - [CI testing: development, PR-head][1]
  - [CI testing: mbedtls-2.28, PR-head][2]
  - [CI testing: fail CMake][3]
  - release testing
    - [development][4]
    - [mbedtls-2.28][5]
- OpenCI:
  - [CI testing: development, PR-head][6]
  - [CI testing: mbedtls-2.28, PR-head][7]
  - [CI testing: fail CMake][8]
  - release testing
    - [development][9]
    - [mbedtls-2.28][10]
    
    
[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-head/89/
[2]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-850-head/14/
[3]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-759-head/30/
[4]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/550/
[5]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/551/
[6]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/15/
[7]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-850-head/8/
[8]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-759-head/6/
[9]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/100/
[10]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/101/