### PR TITLE
Do not run all.sh release components in PR jobs

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -284,6 +284,13 @@ BranchInfo get_branch_information() {
          */
         info.all_all_sh_components['build_armcc'] = 'arm-compilers'
         echo "Overriding all_all_sh_components['build_armcc'] = 'arm-compilers'"
+
+        if (env.JOB_TYPE == 'PR') {
+            // Do not run release components in PR jobs
+            info.all_all_sh_components = info.all_all_sh_components.findAll {
+                component, platform -> !component.startsWith('release')
+            }
+        }
     }
     return info
 }


### PR DESCRIPTION
Filter the all.sh components which are named `component_release_xxx` from PR tests.

Test runs:
- PR tests
  - [No filtered components][1] - Mbed-TLS/mbedtls@d9c69d12acebe89dbdc023e66d25c05d84725aa0
  - [Valgrind components filtered][2] - bensze01/mbedtls@0354d04d3c5258df49cc7d1adcb5f9598dcb16d6
- Release tests
  - [Valgrind components marked, but not filtered][3] - bensze01/mbedtls@0354d04d3c5258df49cc7d1adcb5f9598dcb16d6
 
 [1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/304/
 [2]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/305/
 [3]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/560/