### PR TITLE
speed up analyze-outcomes stage

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -237,16 +237,16 @@ def process_outcomes() {
         deleteDir()
     }
 
-    // The complete outcome file is ~14MB compressed as I write.
+    // The complete outcome file is 2.1GB uncompressed / 56MB compressed as I write.
     // Often we just want the failures, so make an artifact with just those.
     // Only produce a failure file if there was a failing job (otherwise
     // we'd just waste time creating an empty file).
     if (gen_jobs.failed_builds) {
         sh '''\
-awk -F';' '$5 == "FAIL"' outcomes.csv >"failures.csv"
+grep ';FAIL;' outcomes.csv >"failures.csv"
 # Compress the failure list if it is large (for some value of large)
 if [ "$(wc -c <failures.csv)" -gt 99999 ]; then
-    xz failures.csv
+    xz -0 -T8 failures.csv
 fi
 '''
     }
@@ -258,7 +258,7 @@ fi
             }
         }
     } finally {
-        sh 'xz outcomes.csv'
+        sh 'xz -0 -T8 outcomes.csv'
         archiveArtifacts(artifacts: 'outcomes.csv.xz, failures.csv*',
                          fingerprint: true,
                          allowEmptyArchive: true)

--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -241,6 +241,9 @@ def process_outcomes() {
     // Often we just want the failures, so make an artifact with just those.
     // Only produce a failure file if there was a failing job (otherwise
     // we'd just waste time creating an empty file).
+    //
+    // Note that grep ';FAIL;' could pick up false positives, if another field such
+    // as test description or test suite was "FAIL".
     if (gen_jobs.failed_builds) {
         sh '''\
 grep ';FAIL;' outcomes.csv >"failures.csv"

--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -246,10 +246,10 @@ def process_outcomes() {
     // as test description or test suite was "FAIL".
     if (gen_jobs.failed_builds) {
         sh '''\
-grep ';FAIL;' outcomes.csv >"failures.csv"
+LC_ALL=C grep ';FAIL;' outcomes.csv >"failures.csv"
 # Compress the failure list if it is large (for some value of large)
 if [ "$(wc -c <failures.csv)" -gt 99999 ]; then
-    LC_ALL=C xz -0 -T8 failures.csv
+    xz -0 -T8 failures.csv
 fi
 '''
     }

--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -249,7 +249,7 @@ def process_outcomes() {
 LC_ALL=C grep ';FAIL;' outcomes.csv >"failures.csv"
 # Compress the failure list if it is large (for some value of large)
 if [ "$(wc -c <failures.csv)" -gt 99999 ]; then
-    xz -0 -T8 failures.csv
+    xz -0 -T0 failures.csv
 fi
 '''
     }
@@ -261,7 +261,7 @@ fi
             }
         }
     } finally {
-        sh 'xz -0 -T8 outcomes.csv'
+        sh 'xz -0 -T0 outcomes.csv'
         archiveArtifacts(artifacts: 'outcomes.csv.xz, failures.csv*',
                          fingerprint: true,
                          allowEmptyArchive: true)

--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -249,7 +249,7 @@ def process_outcomes() {
 grep ';FAIL;' outcomes.csv >"failures.csv"
 # Compress the failure list if it is large (for some value of large)
 if [ "$(wc -c <failures.csv)" -gt 99999 ]; then
-    xz -0 -T8 failures.csv
+    LC_ALL=C xz -0 -T8 failures.csv
 fi
 '''
     }


### PR DESCRIPTION
Improve perf of the analyse-outcomes stage of CI, which especially matters because it's a serial stage of the CI pipeline.

Currently, it takes around 247s to run xz on the CI.

Testing locally, current xz command takes 130s. With -0, it takes 15s (so expect ~28.5s on CI). This increases compressed size from 38 MB to 54 MB.

Using -T8 (8 threads) reduces it further to 2.6s locally (expect ~5s on CI). There's no penalty for going too big on thread count, but no benefit beyond about 8-16.

lzma, gzip, bzip2, zip are all worse.


Also, use grep instead of awk to extract failures, which saves a few more seconds.

CI run: https://jenkins-mbedtls.oss.arm.com/blue/organizations/jenkins/mbed-tls-pr-head/detail/PR-8530-head/9/pipeline/