### PR TITLE
Fix generation of failures.csv when there are only non-outcome failures

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -246,7 +246,7 @@ def process_outcomes() {
     // as test description or test suite was "FAIL".
     if (gen_jobs.failed_builds) {
         sh '''\
-LC_ALL=C grep ';FAIL;' outcomes.csv >"failures.csv"
+LC_ALL=C grep ';FAIL;' outcomes.csv >"failures.csv" || [ $? -eq 1 ]
 # Compress the failure list if it is large (for some value of large)
 if [ "$(wc -c <failures.csv)" -gt 99999 ]; then
     xz -0 -T0 failures.csv


### PR DESCRIPTION
Fix a corner case from #144 that prevents the upload of `outcomes.csv` when there are failed jobs but no failed test cases (e.g. all tests that compile are passing, but there are configurations where the compilation fails).

Test run:
* development, release job (with Windows-2015 failing and causing the problem): [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/126/)
* 2.28, release job (all passing): [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/127/)

