### PR TITLE
Drop MSVC 2015 testing from nightly builds

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -311,7 +311,7 @@ def get_supported_windows_builds() {
     if (env.JOB_TYPE == 'PR') {
         vs_builds = ['2013']
     } else {
-        vs_builds = ['2013', '2015', '2017']
+        vs_builds = ['2013', '2017']
     }
     echo "vs_builds = ${vs_builds}"
     return ['mingw'] + vs_builds


### PR DESCRIPTION
There is a compiler bug around optimizations that's causing an internal error.

- Internal CI
  - [development][1]
  - [mbedtls-2.28][2]
- OpenCI
  - [development][3]
  - [mbedtls-2.28][4]
  
[1]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/565/
[2]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/566/
[3]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/128/
[4]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/129/