### PR TITLE
Split up windows jobs

### DIFF
--- a/resources/windows/windows_testing.py
+++ b/resources/windows/windows_testing.py
@@ -123,13 +123,21 @@ class MbedWindowsTesting(object):
             self.mingw_directory = os.path.join(
                 "C:", "tools", "mingw64", "bin"
             )
+        if "visual_studio_solution_types" in testing_config.keys():
+            self.visual_studio_solution_types = testing_config["visual_studio_solution_types"]
+        else:
+            self.visual_studio_solution_types = ["shipped", "cmake"]
+        if "visual_studio_retarget_solution" in testing_config.keys():
+            self.visual_studio_retarget_solution = testing_config["visual_studio_retarget_solution"]
+        else:
+            self.visual_studio_retarget_solution = [False, True]
+
         self.vs_version_toolsets = {
             "2010": "100",
             "2013": "120",
             "2015": "140",
             "2017": "141"
         }
-        self.visual_studio_solution_types = ["shipped", "cmake"]
         self.visual_studio_architecture_flags = {"Win32": "x86", "x64": "x64"}
         self.cmake_architecture_flags = {"Win32": "", "x64": " Win64"}
         self.cmake_generators = {
@@ -692,7 +700,7 @@ class MbedWindowsTesting(object):
                     vs_version in self.vs_versions_to_build for
                     configuration in self.visual_studio_configurations for
                     architecture in self.visual_studio_architectures for
-                    retargeted in [False, True] if
+                    retargeted in self.visual_studio_retarget_solution if
                     ((vs_version, architecture) != ("2010", "x64") and
                      (vs_version, retargeted) != ("2010", True))
                 ]

--- a/resources/windows/windows_testing.py
+++ b/resources/windows/windows_testing.py
@@ -190,7 +190,7 @@ class MbedWindowsTesting(object):
         )
         console = logging.StreamHandler()
         file_handler = logging.FileHandler(log_file)
-        if name is not "Results":
+        if name != "Results":
             console.setFormatter(log_formatter)
             file_handler.setFormatter(log_formatter)
         logger = logging.getLogger(name)

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -51,7 +51,7 @@ import org.mbed.tls.jenkins.BranchInfo
 @Field perJobTimeout = [
         time: 120,
         raasOffset: 17,
-        windowsTestingOffset: 60,
+        windowsTestingOffset: -60,
         unit: 'MINUTES'
 ]
 

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -240,35 +240,37 @@ def gen_windows_testing_job(BranchInfo info, String toolchain, String label_pref
     return test_configs.groupBy({ item -> (String) item.group }).collectEntries { group, items ->
         return instrumented_node_job('windows', group) {
             try {
-                dir("src") {
-                    deleteDir()
-                    checkout_repo.checkout_repo(info)
-                }
-                /* The empty files are created to re-create the directory after it
-                 * and its contents have been removed by deleteDir. */
-                dir("logs") {
-                    deleteDir()
-                    writeFile file: '_do_not_delete_this_directory.txt', text: ''
-                }
-
-                dir("worktrees") {
-                    deleteDir()
-                    writeFile file: '_do_not_delete_this_directory.txt', text: ''
-                }
-
-                if (info.has_min_requirements) {
+                stage('checkout') {
                     dir("src") {
-                        timeout(time: common.perJobTimeout.time,
+                        deleteDir()
+                        checkout_repo.checkout_repo(info)
+                    }
+                    /* The empty files are created to re-create the directory after it
+                     * and its contents have been removed by deleteDir. */
+                    dir("logs") {
+                        deleteDir()
+                        writeFile file: '_do_not_delete_this_directory.txt', text: ''
+                    }
+
+                    dir("worktrees") {
+                        deleteDir()
+                        writeFile file: '_do_not_delete_this_directory.txt', text: ''
+                    }
+
+                    if (info.has_min_requirements) {
+                        dir("src") {
+                            timeout(time: common.perJobTimeout.time,
                                 unit: common.perJobTimeout.unit) {
-                            bat "python scripts\\min_requirements.py ${info.python_requirements_override_file}"
+                                bat "python scripts\\min_requirements.py ${info.python_requirements_override_file}"
+                            }
                         }
                     }
-                }
 
-                /* libraryResource loads the file as a string. This is then
-                 * written to a file so that it can be run on a node. */
-                def windows_testing = libraryResource 'windows/windows_testing.py'
-                writeFile file: 'windows_testing.py', text: windows_testing
+                    /* libraryResource loads the file as a string. This is then
+                     * written to a file so that it can be run on a node. */
+                    def windows_testing = libraryResource 'windows/windows_testing.py'
+                    writeFile file: 'windows_testing.py', text: windows_testing
+                }
 
                 analysis.record_inner_timestamps('windows', group) {
                     def exceptions = items.findResults { item ->


### PR DESCRIPTION
Split up the windows tests into individual builds, and group them into ~20 minute sized chucks that share the checkout and python dependency installation steps

CI runs:
  - OpenCI:
    -  [mbedtls-release-ci-testing][1] (0eba489dca91876e976a0c00b65d523c868a7241)
    - PR-head
      - [development - good][3]
      - [mbedtls-2.28 - good][4]
      - [CMake fail][5]
  - Internal CI:
    - [mbedtls-release-ci-testing][2] (0eba489dca91876e976a0c00b65d523c868a7241)
    - PR-head
      - [development - good][6]
      - [mbedtls-2.28 - good][7]
      - [CMake fail][8]
  
[1]: https://mbedtls.trustedfirmware.org/blue/organizations/jenkins/mbedtls-release-ci-testing/detail/mbedtls-release-ci-testing/151/pipeline/
[2]: https://jenkins-mbedtls.oss.arm.com/blue/organizations/jenkins/mbedtls-release-ci-testing/detail/mbedtls-release-ci-testing/584/pipeline/
[3]: https://jenkins-mbedtls.oss.arm.com/blue/organizations/jenkins/mbed-tls-pr-ci-testing/detail/PR-906-head/93/pipeline
[4]: https://jenkins-mbedtls.oss.arm.com/blue/organizations/jenkins/mbed-tls-pr-ci-testing/detail/PR-850-head/2/pipeline
[5]: https://jenkins-mbedtls.oss.arm.com/blue/organizations/jenkins/mbed-tls-pr-ci-testing/detail/PR-759-head/2/pipeline
[6]: https://mbedtls.trustedfirmware.org/blue/organizations/jenkins/mbed-tls-restricted-pr-ci-testing/detail/PR-906-head/16/pipeline
[7]: https://mbedtls.trustedfirmware.org/blue/organizations/jenkins/mbed-tls-restricted-pr-ci-testing/detail/PR-850-head/9/pipeline
[8]: https://mbedtls.trustedfirmware.org/blue/organizations/jenkins/mbed-tls-restricted-pr-ci-testing/detail/PR-759-head/7/pipeline