### PR TITLE
Increase linux testing timeout

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -210,7 +210,7 @@ docker pull $docker_repo:$docker_image
 def docker_script(platform, entrypoint, entrypoint_arguments='') {
     def docker_image = get_docker_tag(platform)
     return """\
-docker run -u \$(id -u):\$(id -g) -e MAKEFLAGS --rm --entrypoint $entrypoint \
+docker run -u \$(id -u):\$(id -g) -e MAKEFLAGS -e VERBOSE_LOGS --rm --entrypoint $entrypoint \
     -w /var/lib/build -v `pwd`/src:/var/lib/build \
     --cap-add SYS_PTRACE $docker_repo:$docker_image $entrypoint_arguments
 """

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -50,7 +50,7 @@ import org.mbed.tls.jenkins.BranchInfo
  * it into account for the on-target test jobs.
  */
 @Field perJobTimeout = [
-        time: 120,
+        time: 240,
         raasOffset: 17,
         windowsTestingOffset: -60,
         unit: 'MINUTES'

--- a/vars/environ.groovy
+++ b/vars/environ.groovy
@@ -26,6 +26,7 @@ def set_common_environment() {
      * avoid that. Do somewhat parallel builds, not just sequential builds,
      * so that the CI has a chance to detect related makefile bugs. */
     env.MAKEFLAGS = '-j2'
+    env.VERBOSE_LOGS=1
 }
 
 def set_tls_pr_environment(is_production) {


### PR DESCRIPTION
We've breached 2 hours in  `all_u16-release_test_valgrind_psa`, so increase the timeout value.

With the current implementation of "silent logging", timeouts also destroy all the logs, so turn verbose logs on for now.

Test run: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/587/