### PR TITLE
Upgrade to Arm Compiler 5.06u7 and 6.21

### DIFF
--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -29,11 +29,36 @@
 # ARMLMD_LICENSE_FILE argument when building the image
 # (docker build --build-arg ARMLMD_LICENSE_FILE=... arm-compilers).
 
-# For now, copy the ARM compilers from a fixed image which is present in our caches.
-# This avoids the problem that the download URLs for Arm compilers are
-# not longer valid.
-ARG DOCKER_REPO
-FROM $DOCKER_REPO:arm-compilers-c568d022eecd6e6263f7bc0f8e94e003dd652160 AS arm-compiler-binaries
+# Download and verify hash of Arm Compiler 6 tarball
+# The URL is provided as a secret, so changing it doesn't trigger a rebuild of the image
+# On the other hand, the hash is provided as a build argument, so changing it *does* trigger a rebuild.
+FROM curlimages/curl-base:8.7.1 AS armc5
+
+# Hash of ARMCompiler_506_Linux_x86_b960.tar.gz - override if you use a different compiler version
+ARG ARMC5_SHA256=85d741527ba91383e419d86be330112d8e9e056adf3ba83d071d5be158ae3b4a
+
+# The build context is mounted under /run/context so you can supply your own local tarball of Arm Compiler 5
+# by pointing curl to file:///run/context/<tarball>
+RUN --mount=type=secret,id=armc5_url,required=true \
+    --mount=type=bind,target=/run/context \
+    { curl "$(cat /run/secrets/armc5_url)" | tee /dev/fd/3 | tar -zx ./Installer/setup.sh; } 3>&1 | \
+    { echo "$ARMC5_SHA256  /dev/fd/3" | sha256sum -c; } 3<&0
+
+RUN ./Installer/setup.sh -d ./armc5 --i-agree-to-the-contained-eula --no-interactive --quiet
+
+FROM curlimages/curl-base:8.7.1 AS armc6
+
+# Hash of ARMCompiler6.21_standalone_linux-x86_64.tar.gz - override if you use a different compiler version
+ARG ARMC6_SHA256=4bcdf9f719a8140b152b699fce8242a68b612cb0cb59f811ae11eb48302d1efe
+
+# The build context is mounted under /run/context so you can supply your own local tarball of Arm Compiler 6
+# by pointing curl to file:///run/context/<tarball>
+RUN --mount=type=secret,id=armc6_url,required=true \
+    --mount=type=bind,target=/run/context \
+    { curl "$(cat /run/secrets/armc6_url)" | tee /dev/fd/3 | tar --exclude license_terms --exclude releasenotes.html -zx; } 3>&1 | \
+    { echo "$ARMC6_SHA256  /dev/fd/3" | sha256sum -c; } 3<&0
+
+RUN ./install_*.sh -d ./armc6 --i-agree-to-the-contained-eula --no-interactive --quiet
 
 FROM ubuntu:20.04
 
@@ -91,13 +116,15 @@ RUN locale && \
     locale-gen "en_US.UTF-8" && \
     dpkg-reconfigure locales
 
-# Install ARM Compiler 5.06 and 6.6
-COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_5.06u3 /usr/local/ARM_Compiler_5.06u3
-COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_6.6 /usr/local/ARM_Compiler_6.6
+# Install ARM Compiler 5.06 and 6.21
+ARG ARMC5_INSTALL_DIR=/usr/local/ARM_Compiler_5.06u7
+ARG ARMC6_INSTALL_DIR=/usr/local/ARM_Compiler_6.21
+COPY --link --from=armc5 --chown=root /home/curl_user/armc5 $ARMC5_INSTALL_DIR
+COPY --link --from=armc6 --chown=root /home/curl_user/armc6 $ARMC6_INSTALL_DIR
 
-ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
-ENV ARMC6_BIN_DIR=/usr/local/ARM_Compiler_6.6/bin/
-ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
+ENV ARMC5_BIN_DIR=$ARMC5_INSTALL_DIR/bin/
+ENV ARMC6_BIN_DIR=$ARMC6_INSTALL_DIR/bin/
+ENV PATH=$PATH:$ARMC5_BIN_DIR
 ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
@@ -113,4 +140,3 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 WORKDIR ${AGENT_WORKDIR}
 
 ENTRYPOINT ["bash"]
-

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -659,14 +659,15 @@ def gen_dockerfile_builder_job(String platform, boolean overwrite=false) {
                 if (overwrite || !image_exists) {
                     dir('docker') {
                         deleteDir()
-                        writeFile file: 'Dockerfile', text: dockerfile
-                        def extra_build_args = ''
+                        try {
+                            writeFile file: 'Dockerfile', text: dockerfile
+                            def extra_build_args = ''
 
-                        if (common.is_open_ci_env) {
-                            extra_build_args = '--build-arg ARMLMD_LICENSE_FILE=27000@flexnet.trustedfirmware.org'
+                            if (common.is_open_ci_env) {
+                                extra_build_args = '--build-arg ARMLMD_LICENSE_FILE=27000@flexnet.trustedfirmware.org'
 
-                            withCredentials([string(credentialsId: 'DOCKER_AUTH', variable: 'TOKEN')]) {
-                                sh """\
+                                withCredentials([string(credentialsId: 'DOCKER_AUTH', variable: 'TOKEN')]) {
+                                    sh """\
 mkdir -p ${env.HOME}/.docker
 cat > ${env.HOME}/.docker/config.json << EOF
 {
@@ -679,35 +680,35 @@ cat > ${env.HOME}/.docker/config.json << EOF
 EOF
 chmod 0600 ${env.HOME}/.docker/config.json
 """
-                            }
-                        } else {
-                            sh """\
+                                }
+                            } else {
+                                sh """\
 aws ecr get-login-password | docker login --username AWS --password-stdin $common.docker_ecr
 """
-                        }
+                            }
 
-                        // Check if the buildkit container already exists
-                        if (sh(script: 'docker buildx inspect dockerfile-builder', returnStatus: true) != 0) {
-                            sh 'docker buildx create --name dockerfile-builder --use'
-                        }
+                            // Check if the buildkit container already exists
+                            if (sh(script: 'docker buildx inspect dockerfile-builder', returnStatus: true) != 0) {
+                                sh 'docker buildx create --name dockerfile-builder --use'
+                            }
 
-                        // Generate URL for armclang
-                        if (platform == 'arm-compilers') {
-                            withCredentials(common.is_open_ci_env ? [] : [aws(credentialsId: 'armclang-readonly-keys')]) {
-                                sh '''
+                            // Generate URL for armclang
+                            if (platform == 'arm-compilers') {
+                                withCredentials(common.is_open_ci_env ? [] : [aws(credentialsId: 'armclang-readonly-keys')]) {
+                                    sh '''
 set -eux
 aws s3 presign --expires-in 300 \
     s3://trustedfirmware-private/armclang/ARMCompiler_506_Linux_x86_b960.tar.gz >armc5_url
 aws s3 presign --expires-in 300 \
     s3://trustedfirmware-private/armclang/ARMCompiler6.21_standalone_linux-x86_64.tar.gz >armc6_url
 '''
-                                extra_build_args +=
-                                    ' --secret id=armc5_url,src=./armc5_url --secret id=armc6_url,src=./armc6_url'
+                                    extra_build_args +=
+                                        ' --secret id=armc5_url,src=./armc5_url --secret id=armc6_url,src=./armc6_url'
+                                }
                             }
-                        }
 
-                        analysis.record_inner_timestamps('dockerfile-builder', platform) {
-                            sh """\
+                            analysis.record_inner_timestamps('dockerfile-builder', platform) {
+                                sh """\
 # Use BuildKit and a remote build cache to pull only the reuseable layers
 # from the last successful build for this platform
 docker buildx build \
@@ -717,6 +718,9 @@ docker buildx build \
     -t $common.docker_repo:$tag \
     --push - <Dockerfile
 """
+                            }
+                        } finally {
+                            deleteDir()
                         }
                     }
                 }


### PR DESCRIPTION
This PR upgrades Arm Compiler 5 to the last released version, and Arm Compiler 6 to the version used by TF-M, by downloading both from the TF armclang S3 bucket. 

Instead of unconditionally downloading the compilers before each docker image build, the CI generates pre-signed download URLs using the configured IAM credentials, and passes these URLs to the docker build as secrets.

This allows docker to effectively reuse the build cache, as changing the URL will not invalidate the cache - only changing the expected hash of the downloaded file will. (`ARMC[56]_SHA`)

This design also allows the Dockerfiles to remain isolated from the underlying infrastructure, and allows developers to generate the `arm-compilers` image locally.

To do so, simply download desired versions of [Arm Compiler 5](https://developer.arm.com/downloads/view/ACOMP5?) and [Arm Compiler 6](https://developer.arm.com/downloads/view/ACOMPE),  place the downloaded files in the `arm-compilers` directory, and run the following commands:

```bash
export ARMC6_URL=file:///run/context/ARMCompiler6.21_standalone_linux-x86_64.tar.gz
export ARMC5_URL=file:///run/context/ARMCompiler_506_Linux_x86_b960.tar.gz
docker build -t mbedtls-jenkins:arm-compilers --secret id=armc6_url,env=ARMC6_URL --secret id=armc5_url,env=ARMC5_URL resources/docker_files/arm-compiler
```

Test runs:
  - [Internal CI, development](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/594/)
  - [OpenCI, development](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/158/)