### PR TITLE
Run result analysis in Docker

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -38,6 +38,7 @@ import jenkins.branch.MultiBranchProject
 import jenkins.util.BuildListenerAdapter
 import net.sf.json.JSONObject
 
+import org.mbed.tls.jenkins.BranchInfo
 import org.mbed.tls.jenkins.JobTimestamps
 
 // A static field has its content preserved across stages.
@@ -228,7 +229,7 @@ def stash_outcomes(job_name) {
 
 // In a directory with the source tree available, process the outcome files
 // from all the jobs.
-def process_outcomes() {
+def process_outcomes(BranchInfo info) {
     dir('csvs') {
         for (stash_name in outcome_stashes) {
             unstash(stash_name)
@@ -268,7 +269,7 @@ fi
     }
 }
 
-def gather_outcomes() {
+def gather_outcomes(BranchInfo info) {
     // After running on an old branch which doesn't have the outcome
     // file generation mechanism, or after running a partial run,
     // there may not be any outcome file. In this case, silently
@@ -280,8 +281,8 @@ def gather_outcomes() {
         dir('outcomes') {
             deleteDir()
             try {
-                checkout_repo.checkout_repo()
-                process_outcomes()
+                checkout_repo.checkout_repo(info)
+                process_outcomes(info)
             } finally {
                 deleteDir()
             }
@@ -289,9 +290,9 @@ def gather_outcomes() {
     }
 }
 
-void analyze_results() {
+void analyze_results(BranchInfo info) {
     try {
-        gather_outcomes()
+        gather_outcomes(info)
     } catch (err) {
         common.maybe_notify_github('FAILURE', 'Result analysis failed')
         throw (err)

--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -272,6 +272,7 @@ tests/scripts/analyze_outcomes.py outcomes.csv
 
     def job_map = gen_jobs.gen_docker_job(info, job_name, 'ubuntu-22.04',
                                           script_in_docker,
+                                          post_checkout: post_checkout,
                                           post_execution: post_execution)
     common.report_errors(job_name, job_map[job_name])
 }

--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -273,10 +273,10 @@ tests/scripts/analyze_outcomes.py outcomes.csv
     def job_map = gen_jobs.gen_docker_job(info, job_name, 'ubuntu-22.04',
                                           script_in_docker,
                                           post_execution: post_execution)
-    job_map[job_name]()
+    common.report_errors(job_name, job_map[job_name])
 }
 
-def gather_outcomes(BranchInfo info) {
+def analyze_results(BranchInfo info) {
     // After running on an old branch which doesn't have the outcome
     // file generation mechanism, or after running a partial run,
     // there may not be any outcome file. In this case, silently
@@ -293,14 +293,5 @@ def gather_outcomes(BranchInfo info) {
                 deleteDir()
             }
         }
-    }
-}
-
-void analyze_results(BranchInfo info) {
-    try {
-        gather_outcomes(info)
-    } catch (err) {
-        common.maybe_notify_github('FAILURE', 'Result analysis failed')
-        throw (err)
     }
 }

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -91,33 +91,47 @@ def platform_lacks_tls_tools(platform) {
     return ['freebsd'].contains(os)
 }
 
-/* gen_docker_job(info, job_name, platform, script_in_docker, ...)
- *
+// gen_docker_job(info, job_name, platform, script_in_docker, ...)
+/**
  * Construct a job that runs a script in Docker.
- * Return a one-element map mapping job_name to a closure that runs the job.
  *
- * Positional parameters:
- * - info: a BranchInfo object describing the branch to test.
- * - job_name: the name to use for the job. It is used as a key in
- *   the returned map, as a name in Jenkins reports and logs, to
- *   construct file names and anywhere else this function needs
- *   a presumed unique job name.
- * - platform: the name of the Docker image.
- * - script_in_docker: a shell script to run in the Docker image.
+ * @return
+ *     A one-element map mapping job_name to a closure that runs the job.
  *
- * Named parameters:
- * - post_checkout: hook that runs after checking out the code to test.
- * - post_success: hook that runs after running the script in Docker, if
- *   that script succeeds.
- * - post_execution: hook that runs after running the script in Docker,
- *   whether it succeeded or not. It can check the job's status by querying
- *   gen_jobs.failed_builds[job_name], which is true if the job failed and
- *   absent otherwise. This hook should not throw an exception.
+ * @param info
+ *     A BranchInfo object describing the branch to test.
+ * @param job_name
+ *     The name to use for the job. It is used as a key in
+ *     the returned map, as a name in Jenkins reports and logs, to
+ *     construct file names and anywhere else this function needs
+ *     a presumed unique job name.
+ * @param platform
+ *     The name of the Docker image.
+ * @param script_in_docker
+ *     A shell script to run in the Docker image.
  *
- * All hook parameters are closures that are called with no arguments.
- * They can be null, in which case the hook does nothing. The code runs
- * on a 'container-host' executor, in the directory containing the
- * source code.
+ * @param hooks
+ *     Named parameters
+ *     <dl>
+ *         <dt>{@code post_checkout}</dt><dd>
+ *             Hook that runs after checking out the code to test.
+ *         </dd>
+ *         <dt>{@code post_success}</dt><dd>
+ *             Hook that runs after running the script in Docker, if
+ *             that script succeeds.
+ *         </dd>
+ *         <dt>{@code post_execution}</dt><dd>
+ *             Hook that runs after running the script in Docker,
+ *             whether it succeeded or not. It can check the job's status by querying
+ *             {@code gen_jobs.failed_builds[job_name]}, which is true if the job failed and
+ *             absent otherwise. This hook should not throw an exception.
+ *         </dd>
+ *     </dl>
+ *
+ *     All hook parameters are closures that are called with no arguments.
+ *     They can be null, in which case the hook does nothing. The code runs
+ *     on a 'container-host' executor, in the directory containing the
+ *     source code.
  */
 Map<String, Callable<Void>> gen_docker_job(Map<String, Closure> hooks,
                                            BranchInfo info,

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -148,24 +148,28 @@ def run_job() {
 void run_release_job() {
     BranchInfo info
     analysis.main_record_timestamps('run_release_job') {
-        environ.set_tls_release_environment()
-        common.init_docker_images()
-        stage('tls-testing') {
-            info = common.get_branch_information()
-            def jobs = common.wrap_report_errors(gen_jobs.gen_release_jobs(info))
-            jobs.failFast = false
+        try {
+            environ.set_tls_release_environment()
+            common.init_docker_images()
+            stage('branch-info') {
+                info = common.get_branch_information()
+            }
             try {
-                try {
+                stage('tls-testing') {
+                    def jobs = common.wrap_report_errors(gen_jobs.gen_release_jobs(info))
+                    jobs.failFast = false
                     analysis.record_inner_timestamps('main', 'run_release_job') {
                         parallel jobs
                     }
                 }
-                finally {
-                    stage('result-analysis') {
-                        analysis.analyze_results(info)
-                    }
+            }
+            finally {
+                stage('result-analysis') {
+                    analysis.analyze_results(info)
                 }
-            } finally {
+            }
+        } finally {
+            stage('email-report') {
                 if (currentBuild.rawBuild.causes[0] instanceof ParameterizedTimerTriggerCause ||
                     currentBuild.rawBuild.causes[0] instanceof TimerTrigger.TimerTriggerCause) {
                     common.send_email('Mbed TLS nightly tests', env.MBED_TLS_BRANCH, gen_jobs.failed_builds, gen_jobs.coverage_details)

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -132,7 +132,7 @@ def run_pr_job(is_production=true) {
             }
         } finally {
             stage('result-analysis') {
-                analysis.analyze_results()
+                analysis.analyze_results(info)
             }
         }
 
@@ -146,12 +146,13 @@ def run_job() {
 }
 
 void run_release_job() {
+    BranchInfo info
     analysis.main_record_timestamps('run_release_job') {
         try {
             environ.set_tls_release_environment()
             common.init_docker_images()
             stage('tls-testing') {
-                BranchInfo info = common.get_branch_information()
+                info = common.get_branch_information()
                 def jobs = common.wrap_report_errors(gen_jobs.gen_release_jobs(info))
                 jobs.failFast = false
                 try {
@@ -168,7 +169,7 @@ void run_release_job() {
         }
         finally {
             stage('result-analysis') {
-                analysis.analyze_results()
+                analysis.analyze_results(info)
             }
         }
     }


### PR DESCRIPTION
[Run result analysis in the same environment as test jobs: in a Docker image, with our Python requirements installed. This does most of the work towards Mbed-TLS/mbedtls#8300: we'll be able to run `make generated_files`.

We could finish resolving <!-- nogrep --> https://github.com/Mbed-TLS/mbedtls/issues/8300 here by running `tests/scripts/check-generated-files.sh -u` here. (Not `make generated_files` because that doesn't exist in 2.28.) But I would prefer to pull the switch in an `mbedtls` pull request that changes `analyze_outcomes.py` to run `make generated_files`. I'm open to counter-arguments though.

Also, as a result of refactoring:

* Resolves https://github.com/Mbed-TLS/mbedtls-test/issues/134
* Resolves maybe https://github.com/Mbed-TLS/mbedtls-test/issues/120 in passing. This is not fully satisfactory because if there is both a failure in all.sh and a failure of result analysis, only the all.sh failure is reported on GitHub. See https://github.com/Mbed-TLS/mbedtls-restricted/pull/1227 (
![screenshot](https://github.com/Mbed-TLS/mbedtls-test/assets/26596258/a9811631-cf21-46c3-b850-8d587661ac7d)): OpenCI last ran the current `master` and reports only the result analysis failure, whereas Internal CI last ran d39c220cc5c950f17268540650816e2aa5638c8d from this PR and reports only the all.sh component failure. Since this is out of scope, and it's an improvement (result analysis tends not to be useful if there are failing tests), I don't intend to work any more on this here.

Test jobs on d39c220cc5c950f17268540650816e2aa5638c8d:

* Release job on `development`: [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/189/) (log of [result analysis](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/189/execution/node/8997/log/))
* Release job in `mbedtls-2.28`: [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/190/) (log of [result analysis](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/190/execution/node/7238/log/))
* PR job with [outcome analysis failure](https://github.com/Mbed-TLS/mbedtls-restricted/pull/1225): [Internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-1225-head/1/)
* PR job with [both test and outcome analysis failure](https://github.com/Mbed-TLS/mbedtls-restricted/pull/1227): [Internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-1227-head/1/)
* PR job with [build failures](https://github.com/Mbed-TLS/mbedtls-restricted/pull/759): [OpenCI](https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/job/PR-759-head/9/)
* PR-merge job with [passing ABI check](https://github.com/Mbed-TLS/mbedtls-restricted/pull/906): [OpenCI](https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-merge/15/)
* PR-merge job with [failing ABI check](https://github.com/Mbed-TLS/mbedtls-restricted/pull/758): [OpenCI](https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-758-merge/4/)

Test jobs on 45fa0fb99bdc5d9742dbf43e593d29f964b416e8 (changes only in `run_release_job`):
* Release job on `development`: [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/214/)
* Release job with [outcome analysis failure](https://github.com/Mbed-TLS/mbedtls-restricted/pull/1225): [Internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/607/)
