### PR TITLE
Use Python ≥3.6 everywhere

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -58,6 +58,8 @@ RUN apt-get update -q && apt-get install -yq \
         clang-3.5 \
         # to build Mbed TLS
         cmake \
+        # to build Python
+        curl \
         # to build Mbed TLS's documentation
         doxygen \
         # to run tests in specific time.
@@ -70,12 +72,30 @@ RUN apt-get update -q && apt-get install -yq \
         graphviz \
         # to measure code coverage of Mbed TLS
         lcov \
+        # to build Python
+        libbz2-dev \
+        # to build Python
+        libffi-dev \
         # to build GnuTLS (nettle with public key support aka hogweed)
         libgmp-dev \
+        # to build Python
+        liblzma-dev \
+        # to build Python
+        libncursesw5-dev \
+        # to build Python
+        libreadline-dev \
+        # to build Python
+        libsqlite3-dev \
+        # to build Python
+        libssl-dev \
         # to build GnuTLS >= 3.6 (could also use --with-included-unistring)
         libunistring-dev \
         # to build GnuTLS (except 3.6 which uses --with-included-libtasn1)
         libtasn1-6-dev \
+        # to build Python
+        libxml2-dev \
+        # to build Python
+        libxmlsec1-dev \
         # to have a UTF-8 locale (see locale-gen below)
         locales \
         # used by compat.sh and ssl-opt.sh
@@ -88,15 +108,19 @@ RUN apt-get update -q && apt-get install -yq \
         pkg-config \
         # to install the preferred version of pylint
         python3-pip \
+        # to build Python
+        tk-dev \
         # for Mbed TLS tests
         valgrind \
         # for data files generating. xxd is provide by vim
         vim \
         # to download things installed from other places
         wget \
-        # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
+        # to build Python
+        xz-utils \
+        # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0), and to build Python
         zlib1g \
-        # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0)
+        # to build Mbed TLS with MBEDTLS_ZILIB_SUPPORT (removed in 3.0), and to build Python
         zlib1g-dev \
     && case "$(uname -m)" in \
         # x86_64 only packages
@@ -277,6 +301,19 @@ RUN wget -q https://github.com/lvc/abi-compliance-checker/archive/2.3.tar.gz && 
 # The version in Ubuntu 16.04 is too old, we want at least the version below
 RUN git clone --branch 1.1 https://github.com/lvc/abi-dumper.git && \
     cd abi-dumper && make install prefix=/usr && cd .. && rm -rf abi-dumper
+
+# Install Python 3.6 and make it the default `python3` in $PATH.
+# This is the minimum Python version that we declare as required for
+# Mbed TLS 2.28 LTS.
+RUN wget -q https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.0.tar.gz && \
+    tar -xzf v2.4.0.tar.gz && \
+    rm v2.4.0.tar.gz && \
+    cd pyenv-*/ && \
+    bin/pyenv install 3.6 && \
+    ln -s ~/.pyenv/versions/3.6.*/bin/*3.6 /usr/local/bin/ && \
+    ln -s python3.6 /usr/local/bin/python3 && \
+    ln -s pip3.6 /usr/local/bin/pip3 && \
+    ln -s "$PWD/src/pyenv" /usr/local/bin/
 
 # Install Python pip packages
 #

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -315,22 +315,14 @@ RUN wget -q https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.0.tar.gz && \
     ln -s pip3.6 /usr/local/bin/pip3 && \
     ln -s "$PWD/src/pyenv" /usr/local/bin/
 
-# Install Python pip packages
-#
-# The pip wrapper scripts can get out of sync with pip due to upgrading it
-# outside the package manager, so invoke the module directly.
-#
-# Ubuntu 16.04's pip (8.1) doesn't understand the Requires-Python
-# directive (introduced in pip 9.0), and tries to install the wrong versions
-# of pip and setuptools. Version 21 of pip drops support for Python 3.5 (the
-# latest in 16.04), so pick an earlier version.
-#
-# Piping to cat suppresses the progress bar, but means that a failure
-# won't be caught (`stuff | cat` succeeds if cat succeeds, even if `stuff`
-# fails). The subsequent use of "pip config" (which requires pip >=10)
-# will however fail if the installation of a more recent pip failed.
-RUN python3 -m pip install 'pip<21' --upgrade | cat && \
-    python3 -m pip config set global.progress_bar off && \
+RUN python3 -m pip config set global.progress_bar off && \
+    # Python 3.6 from pyenv comes with pip 18.1.
+    # We want the ability to specify both a versioned requirement and an
+    # unversioned requirement for the same package (e.g.
+    # `pip install foo bar foo==42`), and this is only possible since
+    # pip 20.3. So upgrade pip, to the last version that still supports
+    # Python 3.6.
+    python3 -m pip install 'pip<22' --upgrade && \
     python3 -m pip install setuptools --upgrade && \
     true
 

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -277,14 +277,17 @@ RUN git clone --branch uncrustify-0.75.1 https://github.com/uncrustify/uncrustif
 # outside the package manager, so invoke the module directly.
 #
 # Ubuntu 18.04's pip (9.0.1) doesn't support suppressing the progress bar,
-# which is annoying in CI logs. Install pip<21, same as on Ubuntu 16.04
-# (although we could use a later version if we wanted).
+# which is annoying in CI logs. Also, we want the ability to specify both
+# a versioned requirement and an unversioned requirement for the same
+# package (e.g. `pip install foo bar foo==42`), and this is only possible
+# since pip 20.3. So upgrade pip, to the last version that still supports
+# Python 3.6.
 #
 # Piping to cat suppresses the progress bar, but means that a failure
 # won't be caught (`stuff | cat` succeeds if cat succeeds, even if `stuff`
 # fails). The subsequent use of "pip config" (which requires pip >=10)
 # will however fail if the installation of a more recent pip failed.
-RUN python3 -m pip install pip --upgrade | cat && \
+RUN python3 -m pip install 'pip<22' --upgrade | cat && \
     python3 -m pip config set global.progress_bar off && \
     python3 -m pip install setuptools --upgrade && \
     true


### PR DESCRIPTION
Install Python 3.6 on the Ubuntu 16.04 Docker image and make it the default. With this change, our CI now runs with Python ≥3.6 everywhere. Python 3.6 is the oldest version we need to support [for Mbed TLS 2.28 LTS](https://github.com/Mbed-TLS/mbedtls/blob/mbedtls-2.28/README.md#tool-versions).

Test runs at a4badb998e13d0f85d7805776fc8a39a9695267d:

* `development`, release : [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/208/). A [log](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/208/execution/node/1682/log/) showing `python3: /usr/local/bin/python3 : Python 3.6.15` on `ubuntu-16.04-*`.
* `mbedtls-2.28`, release: [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/209/)
* `development`, stablity checks: [Internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/326/)
* `development`, release: [Internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/604/)
* [dropping Python 3.5 compatibility from `development`](https://github.com/Mbed-TLS/mbedtls/pull/9101): [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/210/)
