### PR TITLE
Run API-ABI check on Ubuntu 18.04

### DIFF
--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -34,7 +34,7 @@ void run_tls_tests(BranchInfo info, String label_prefix='') {
         jobs = jobs + gen_jobs.gen_release_jobs(info, label_prefix, false)
 
         if (env.RUN_ABI_CHECK == "true") {
-            jobs = jobs + gen_jobs.gen_abi_api_checking_job(info, 'ubuntu-16.04')
+            jobs = jobs + gen_jobs.gen_abi_api_checking_job(info, 'ubuntu-18.04')
         }
 
         jobs = common.wrap_report_errors(jobs)


### PR DESCRIPTION
The version of Git on 16.04 does not attempt to fetch submodule commits by hash, causing CI failures if PRs are submitted to the framework repo from forks.

Tests (PR-merge):
 - development: [Internal][1] / [Open CI][2]
 - mbedtls-3.6:   [Internal][3] / [Open CI][4]
 - mbedtls-2.28: [Internal][5] / [Open CI][6]
 - ABI break:       [Internal][7] / [Open CI][8]
 
 Tests with the framework submodule pointing to a commit only found in a fork:
 - pre-fix:   [Internal][9] / [Open CI][10]
 - post-fix: [Internal][11] / [Open CI][12]
 
 [1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-merge/139/
 [2]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-merge/18/
 [3]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-1233-merge/2/
 [4]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-1233-merge/2/
 [5]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-850-merge/3/
 [6]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-850-merge/6/
 [7]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-758-merge/1/
 [8]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-758-merge/7/
 [9]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/327/
[10]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/26/
[11]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/329/
[12]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/27/