### PR TITLE
Update crypto directory name

### DIFF
--- a/resources/windows/windows_testing.py
+++ b/resources/windows/windows_testing.py
@@ -291,9 +291,9 @@ class MbedWindowsTesting(object):
         are present, and if not, creates them."""
         seed_filename = os.path.join(git_worktree_path, "tests/seedfile")
         self.generate_seedfile(seed_filename)
-        if os.path.isdir(os.path.join(git_worktree_path, "crypto")):
+        if os.path.isdir(os.path.join(git_worktree_path, "tf-psa-crypto/tests")):
             crypto_seed_filename = os.path.join(git_worktree_path,
-                "crypto/tests/seedfile")
+                "tf-psa-crypto/tests/seedfile")
             self.generate_seedfile(crypto_seed_filename)
 
     def test_mingw_built_code(self):


### PR DESCRIPTION
For the testing on Windows following the move of crypto test suites into the tf-psa-crypto directory we need to create a seedfile in `tf-psa-crypto/tests/`. It seems it has been done for the previous repo split but with a different crypto directory name. Thus update this name.