### PR TITLE
Fix analysis step to use only a single helper-container-host executor

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -227,9 +227,16 @@ def stash_outcomes(job_name) {
     }
 }
 
-// In a directory with the source tree available, process the outcome files
-// from all the jobs.
-def process_outcomes(BranchInfo info) {
+/** Process the outcome files from all the jobs */
+def analyze_results(BranchInfo info) {
+    // After running on an old branch which doesn't have the outcome
+    // file generation mechanism, or after running a partial run,
+    // there may not be any outcome file. In this case, silently
+    // do nothing.
+    if (outcome_stashes.isEmpty()) {
+        return
+    }
+
     String job_name = 'result-analysis'
 
     Closure post_checkout = {
@@ -278,15 +285,4 @@ tests/scripts/analyze_outcomes.py outcomes.csv
                                           post_checkout: post_checkout,
                                           post_execution: post_execution)
     common.report_errors(job_name, job_map[job_name])
-}
-
-def analyze_results(BranchInfo info) {
-    // After running on an old branch which doesn't have the outcome
-    // file generation mechanism, or after running a partial run,
-    // there may not be any outcome file. In this case, silently
-    // do nothing.
-    if (outcome_stashes.isEmpty()) {
-        return
-    }
-    process_outcomes(info)
 }

--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -229,11 +229,10 @@ def stash_outcomes(job_name) {
 
 /** Process the outcome files from all the jobs */
 def analyze_results(BranchInfo info) {
-    // After running on an old branch which doesn't have the outcome
-    // file generation mechanism, or after running a partial run,
-    // there may not be any outcome file. In this case, silently
-    // do nothing.
+    // After running a partial run, there may not be any outcome file.
+    // In this case do nothing.
     if (outcome_stashes.isEmpty()) {
+        echo 'outcome_stashes is empty, skipping result-analysis.'
         return
     }
 

--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -230,7 +230,7 @@ def stash_outcomes(job_name) {
 // In a directory with the source tree available, process the outcome files
 // from all the jobs.
 def process_outcomes(BranchInfo info) {
-    String job_name = 'outcome_analysis'
+    String job_name = 'result-analysis'
 
     Closure post_checkout = {
         dir('csvs') {
@@ -270,7 +270,10 @@ tests/scripts/analyze_outcomes.py outcomes.csv
                          allowEmptyArchive: true)
     }
 
-    def job_map = gen_jobs.gen_docker_job(info, job_name, 'ubuntu-22.04-amd64',
+    def job_map = gen_jobs.gen_docker_job(info,
+                                          job_name,
+                                          'helper-container-host',
+                                          'ubuntu-22.04-amd64',
                                           script_in_docker,
                                           post_checkout: post_checkout,
                                           post_execution: post_execution)
@@ -285,14 +288,5 @@ def analyze_results(BranchInfo info) {
     if (outcome_stashes.isEmpty()) {
         return
     }
-    node_record_timestamps('helper-container-host', 'result-analysis') {
-        dir('outcomes') {
-            deleteDir()
-            try {
-                process_outcomes(info)
-            } finally {
-                deleteDir()
-            }
-        }
-    }
+    process_outcomes(info)
 }

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -128,9 +128,10 @@ def platform_lacks_tls_tools(platform) {
 Map<String, Callable<Void>> gen_docker_job(Map<String, Closure> hooks,
                                            BranchInfo info,
                                            String job_name,
+                                           String node_label = 'container-host',
                                            String platform,
                                            String script_in_docker) {
-    return instrumented_node_job('container-host', job_name) {
+    return instrumented_node_job(node_label, job_name) {
         try {
             deleteDir()
             common.get_docker_image(platform)
@@ -153,7 +154,7 @@ fi
             timeout(time: common.perJobTimeout.time,
                     unit: common.perJobTimeout.unit) {
                 try {
-                    analysis.record_inner_timestamps('container-host', job_name) {
+                    analysis.record_inner_timestamps(node_label, job_name) {
                         sh common.docker_script(
                                 platform, "/var/lib/build/steps.sh"
                         )


### PR DESCRIPTION
This PR restores the intended behaviour of the `analysis` step, that it runs on a `helper-container-host` instance.

The current upstream code reserves a `helper-container-host` but actually runs all the tests on a dfferent, `container-host` executor

Test runs:
- OpenCI
  - Supposed to pass
    - development: [PR-head][openci-development-head] [PR-merge][openci-development-merge]
    - mbedtls-3.6: [PR-head][openci-3.6-head] [PR-merge][openci-3.6-merge]
    - mbedtls-2.28: [PR-head][openci-2.28-head] [PR-merge][openci-2.28-merge]
  - Supposed to fail
    - [Fail all CMake builds][openci-cmake]
    - [Unexecuted test][openci-unexecuted]
 - Internal CI
  - Supposed to pass
    - development: [PR-head][internal-development-head] [PR-merge][internal-development-merge]
    - mbedtls-3.6: [PR-head][internal-3.6-head] [PR-merge][internal-3.6-merge]
    - mbedtls-2.28: [PR-head][internal-2.28-head] [PR-merge][internal-2.28-merge]
  - Supposed to fail
    - [Fail all CMake builds][internal-cmake]
    - [Unexecuted test][internal-unexecuted]
    
[openci-development-head]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/23/
[openci-development-merge]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-merge/24/
[openci-3.6-head]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-1233-head/3/
[openci-3.6-merge]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-1233-merge/6/
[openci-2.28-head]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-850-head/12/
[openci-2.28-merge]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-850-merge/10/
[openci-cmake]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-759-head/12/
[openci-unexecuted]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-919-head/3/
[internal-development-head]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-head/122/
[internal-development-merge]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-merge/157/
[internal-3.6-head]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-1233-head/8/
[internal-3.6-merge]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-1233-merge/8/
[internal-2.28-head]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-850-head/10/
[internal-2.28-merge]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-850-merge/10/
[internal-cmake]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-759-head/9/
[internal-unexecuted]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-919-head/1/
