### PR TITLE
Fix pushing to the coverity_scan branch

### DIFF
--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -621,7 +621,8 @@ def gen_coverity_push_jobs() {
                     checkout_repo.checkout_repo()
                     sshagent([env.GIT_CREDENTIALS_ID]) {
                         analysis.record_inner_timestamps('container-host', job_name) {
-                            sh 'git push origin HEAD:coverity_scan'
+                            // Git complains about non-fast-forward operations when trying to push a shallow commit
+                            sh 'git fetch --unshallow && git push origin HEAD:coverity_scan'
                         }
                     }
                 }


### PR DESCRIPTION
Trying to push shallow commits was failing due to git not being able to verify that this was a fast-forward operation.

CI test run: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/716/