### PR TITLE
Switch to using User-based Licensing on the OpenCI

### DIFF
--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -67,10 +67,6 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /opt/src
 
-# Note: scripts/min_requirements.py need a writable
-# destination for installing python dependencies
-ENV HOME=/var/lib/builds
-
 # Support for i386:
 # - for 32-bit builds+tests of Mbed TLS
 # - required to install Arm Compiler 5.06 (armcc)
@@ -141,8 +137,11 @@ ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 RUN useradd -m user
 
 # Create workspace
-ARG AGENT_WORKDIR=/var/lib/builds
+# Note: scripts/min_requirements.py need a writable
+# destination for installing python dependencies
+ARG AGENT_WORKDIR=/var/lib/build
 RUN mkdir -p ${AGENT_WORKDIR} && chown user:user ${AGENT_WORKDIR}
+ENV HOME=$AGENT_WORKDIR
 USER user
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 

--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -29,11 +29,38 @@
 # ARMLMD_LICENSE_FILE argument when building the image
 # (docker build --build-arg ARMLMD_LICENSE_FILE=... arm-compilers).
 
-# For now, copy the ARM compilers from a fixed image which is present in our caches.
-# This avoids the problem that the download URLs for Arm compilers are
-# not longer valid.
-ARG DOCKER_REPO
-FROM $DOCKER_REPO:arm-compilers-c568d022eecd6e6263f7bc0f8e94e003dd652160 AS arm-compiler-binaries
+# Download and verify hash of Arm Compiler 6 tarball
+# The URL is provided as a secret, so changing it doesn't invalidate the build cache.
+# On the other hand, the hash is provided as a build argument, so changing it *does*
+# invalidate the cache and triggers a rebuild.
+FROM curlimages/curl-base:latest AS armc6
+
+# Hash of ARMCompiler6.21_standalone_linux-x86_64.tar.gz
+# Override if you use a different compiler version
+ARG ARMC6_SHA256=4bcdf9f719a8140b152b699fce8242a68b612cb0cb59f811ae11eb48302d1efe
+
+# The build context is mounted under /run/context so you can supply your own
+# local tarball of Arm Compiler 6 by placing the <gzipped tarball> in the
+# folder of the Dockerfile, and building the image with the following parameters:
+# $ ARMC6_URL=file:///run/context/<gzipped tarball>
+# $ docker build \
+#       -t jenkins-mbedtls:arm-compilers \
+#       --secret id=armc6_url,env=ARMC6_URL \
+#       resources/docker_files/arm-compilers
+RUN --mount=type=secret,id=armc6_url,required=true \
+    --mount=type=bind,target=/run/context \
+    { \
+        curl "$(cat /run/secrets/armc6_url)" | tee /dev/fd/3 | \
+        tar --exclude license_terms --exclude releasenotes.html -zx; \
+    } 3>&1 | { \
+        echo "$ARMC6_SHA256  /dev/fd/3" | sha256sum -c; \
+    } 3<&0
+
+RUN ./install_*.sh \
+        -d ./armc6 \
+        --i-agree-to-the-contained-eula \
+        --no-interactive \
+        --quiet
 
 FROM ubuntu:20.04
 
@@ -91,13 +118,22 @@ RUN locale && \
     locale-gen "en_US.UTF-8" && \
     dpkg-reconfigure locales
 
-# Install ARM Compiler 5.06 and 6.6
-COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_5.06u3 /usr/local/ARM_Compiler_5.06u3
-COPY --link --from=arm-compiler-binaries /usr/local/ARM_Compiler_6.6 /usr/local/ARM_Compiler_6.6
+# Install ARM Compiler 6.21
+ARG ARMC6_INSTALL_DIR=/usr/local/ARM_Compiler_6.21
+ENV ARMC6_BIN_DIR=$ARMC6_INSTALL_DIR/bin/
+COPY --link --from=armc6 --chown=root /home/curl_user/armc6 $ARMC6_INSTALL_DIR
 
-ENV ARMC5_BIN_DIR=/usr/local/ARM_Compiler_5.06u3/bin/
-ENV ARMC6_BIN_DIR=/usr/local/ARM_Compiler_6.6/bin/
-ENV PATH=$PATH:/usr/local/ARM_Compiler_5.06u3/bin
+# HACK: Versions of all.sh that support ArmCC 5 detect the presence of armcc 5
+#       and 6 in a single operation, so fake the presence of ArmCC 5 to make
+#       un-rebased PRs happy
+
+ENV ARMC5_BIN_DIR=/usr/local/Fake_ARM_Compiler_5
+RUN mkdir $ARMC5_BIN_DIR && \
+    ln -s /bin/true $ARMC5_BIN_DIR/armcc && \
+    ln -s /bin/true $ARMC5_BIN_DIR/armar && \
+    ln -s /bin/true $ARMC5_BIN_DIR/fromelf
+
+
 ARG ARMLMD_LICENSE_FILE=7010@10.6.26.52:7010@10.6.26.53:7010@10.6.26.54:7010@10.6.26.56
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
@@ -113,4 +149,3 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 WORKDIR ${AGENT_WORKDIR}
 
 ENTRYPOINT ["bash"]
-

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /opt/src
 
 # Note: scripts/min_requirements.py need a writable
 # destination for installing python dependencies
+# FIXME: this houls be /var/lib/build to use the host src directory as HOME
 ENV HOME=/var/lib/builds
 
 # Support for 32-bit builds+tests of Mbed TLS
@@ -335,6 +336,7 @@ RUN locale && \
 RUN useradd -m user
 
 # Create workspace
+# FIXME: this houls be /var/lib/build to use the host src directory as HOME
 ARG AGENT_WORKDIR=/var/lib/builds
 RUN mkdir -p ${AGENT_WORKDIR} && chown user:user ${AGENT_WORKDIR}
 USER user

--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /opt/src
 
 # Note: scripts/min_requirements.py need a writable
 # destination for installing python dependencies
-# FIXME: this houls be /var/lib/build to use the host src directory as HOME
+# FIXME: This should be /var/lib/build to use the host src directory as HOME
 ENV HOME=/var/lib/builds
 
 # Support for 32-bit builds+tests of Mbed TLS
@@ -336,7 +336,7 @@ RUN locale && \
 RUN useradd -m user
 
 # Create workspace
-# FIXME: this houls be /var/lib/build to use the host src directory as HOME
+# FIXME: This should be /var/lib/build to use the host src directory as HOME
 ARG AGENT_WORKDIR=/var/lib/builds
 RUN mkdir -p ${AGENT_WORKDIR} && chown user:user ${AGENT_WORKDIR}
 USER user

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /opt/src
 
 # Note: scripts/min_requirements.py need a writable
 # destination for installing python dependencies
+# FIXME: this houls be /var/lib/build to use the host src directory as HOME
 ENV HOME=/var/lib/builds
 
 # Support for 32-bit builds+tests of Mbed TLS

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /opt/src
 
 # Note: scripts/min_requirements.py need a writable
 # destination for installing python dependencies
-# FIXME: this houls be /var/lib/build to use the host src directory as HOME
+# FIXME: This should be /var/lib/build to use the host src directory as HOME
 ENV HOME=/var/lib/builds
 
 # Support for 32-bit builds+tests of Mbed TLS

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /opt/src
 
 # Note: scripts/min_requirements.py need a writable
 # destination for installing python dependencies
+# FIXME: this houls be /var/lib/build to use the host src directory as HOME
 ENV HOME=/var/lib/builds
 
 # Support for 32-bit builds+tests of Mbed TLS
@@ -293,6 +294,7 @@ RUN locale && \
 RUN useradd -m user
 
 # Create workspace
+# FIXME: this houls be /var/lib/build to use the host src directory as HOME
 ARG AGENT_WORKDIR=/var/lib/builds
 RUN mkdir -p ${AGENT_WORKDIR} && chown user:user ${AGENT_WORKDIR}
 USER user

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /opt/src
 
 # Note: scripts/min_requirements.py need a writable
 # destination for installing python dependencies
-# FIXME: this houls be /var/lib/build to use the host src directory as HOME
+# FIXME: This should be /var/lib/build to use the host src directory as HOME
 ENV HOME=/var/lib/builds
 
 # Support for 32-bit builds+tests of Mbed TLS
@@ -294,7 +294,7 @@ RUN locale && \
 RUN useradd -m user
 
 # Create workspace
-# FIXME: this houls be /var/lib/build to use the host src directory as HOME
+# FIXME: This should be /var/lib/build to use the host src directory as HOME
 ARG AGENT_WORKDIR=/var/lib/builds
 RUN mkdir -p ${AGENT_WORKDIR} && chown user:user ${AGENT_WORKDIR}
 USER user

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /opt/src
 
 # Note: scripts/min_requirements.py need a writable
 # destination for installing python dependencies
-# FIXME: this houls be /var/lib/build to use the host src directory as HOME
+# FIXME: This should be /var/lib/build to use the host src directory as HOME
 ENV HOME=/var/lib/builds
 
 # Support for 32-bit builds+tests of Mbed TLS
@@ -302,7 +302,7 @@ RUN locale && \
 RUN useradd -m user
 
 # Create workspace
-# FIXME: this houls be /var/lib/build to use the host src directory as HOME
+# FIXME: This should be /var/lib/build to use the host src directory as HOME
 ARG AGENT_WORKDIR=/var/lib/builds
 RUN mkdir -p ${AGENT_WORKDIR} && chown user:user ${AGENT_WORKDIR}
 USER user

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /opt/src
 
 # Note: scripts/min_requirements.py need a writable
 # destination for installing python dependencies
+# FIXME: this houls be /var/lib/build to use the host src directory as HOME
 ENV HOME=/var/lib/builds
 
 # Support for 32-bit builds+tests of Mbed TLS
@@ -301,6 +302,7 @@ RUN locale && \
 RUN useradd -m user
 
 # Create workspace
+# FIXME: this houls be /var/lib/build to use the host src directory as HOME
 ARG AGENT_WORKDIR=/var/lib/builds
 RUN mkdir -p ${AGENT_WORKDIR} && chown user:user ${AGENT_WORKDIR}
 USER user

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -206,10 +206,16 @@ docker pull $docker_repo:$docker_image
     }
 }
 
-def docker_script(platform, entrypoint, entrypoint_arguments='') {
+String docker_script(
+    String platform,
+    String entrypoint,
+    String entrypoint_arguments='',
+    Iterable<String> env_vars=[]
+) {
     def docker_image = get_docker_tag(platform)
+    def env_args = env_vars.collect({ e -> "-e $e" }).join(' ')
     return """\
-docker run -u \$(id -u):\$(id -g) -e MAKEFLAGS -e VERBOSE_LOGS --rm --entrypoint $entrypoint \
+docker run -u \$(id -u):\$(id -g) -e MAKEFLAGS -e VERBOSE_LOGS $env_args --rm --entrypoint $entrypoint \
     -w /var/lib/build -v `pwd`/src:/var/lib/build \
     --cap-add SYS_PTRACE $docker_repo:$docker_image $entrypoint_arguments
 """

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -739,7 +739,8 @@ DOCKER_BUILDKIT=1 docker build \
     --cache-from $common.docker_repo:$cache \
     --cache-from $common.docker_repo:$image-cache \
     -t $common.docker_repo:$tag \
-    -t $common.docker_repo:$cache .
+    -t $common.docker_repo:$cache \
+    - <Dockerfile
 
 # Push the image with its unique tag, as well as the build cache tag
 docker push $common.docker_repo:$tag


### PR DESCRIPTION
Also upgrade to Arm Compiler 6.21 and drop testing on Arm Compiler 5

Test runs:
- Internal CI
  - pr-ci-testing
    - [development][1]
    - [mbedtls-3.6][2]
    - [mbedtls-2.28][3]
  - release-ci-testing
    - [development][7]
    - [mbedtls-3.6][8]
    - [mbedtls-2.28][9]
- OpenCI
  - pr-ci-testing
    - [development][4]
    - [mbedtls-3.6][5]
    - [mbedtls-2.28][6]
  - release-ci-testing
    - [development][10]
    - [mbedtls-3.6][11]
    - [mbedtls-2.28][12]
  
[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-head/123/
[2]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-1233-head/9/
[3]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-850-head/11/
[4]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/26/
[5]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-1233-head/6/
[6]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-850-head/15/
[7]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/721/
[8]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/722/
[9]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/723/
[10]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/282/
[11]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/283/
[12]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/284/