### PR TITLE
Use BRANCH_NAME in run_pr_job if CHANGE_BRANCH is unset

### DIFF
--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -156,6 +156,7 @@ void run_pr_job(String target_repo, boolean is_production, List<String> branches
 
 /* main job */
 void run_job() {
+    // CHANGE_BRANCH is not set in "branch" jobs, eg. in the merge queue
     run_pr_job('tls', true, env.CHANGE_BRANCH ?: env.BRANCH_NAME)
 }
 

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -156,7 +156,7 @@ void run_pr_job(String target_repo, boolean is_production, List<String> branches
 
 /* main job */
 void run_job() {
-    run_pr_job('tls', true, env.CHANGE_BRANCH)
+    run_pr_job('tls', true, env.CHANGE_BRANCH ?: env.BRANCH_NAME)
 }
 
 void run_framework_pr_job() {


### PR DESCRIPTION
When running on a branch rather than a PR (eg. on a merge-queue branch), the Git plugin doesn't set CHANGE_BRANCH - in these cases, BRANCH_NAME contains the name of the branch.

Test runs:
- Internal CI:
  - [Merge queue][1]
  - [PR-head][2]
- OpenCI:
  - [Merge queue][3]
  - [PR-head][4]
  
[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/job/dev%252Fdgreen-arm%252Fci-testing-development/2/
[2]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-head/125/
[3]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/job/dev%252Fdgreen-arm%252Fci-testing-development/2/
[4]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/27/