### PR TITLE
Fix sending test-result E-mails

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -417,7 +417,9 @@ void send_email(String name, Collection<BranchInfo> infos) {
     String branches = infos*.branch.join(',')
     def failed_builds = infos.collectMany { info -> info.failed_builds}
     String coverage_details = infos.collect({info -> "$info.branch:\n$info.coverage_details"}).join('\n\n')
-    if (failed_builds) {
+
+    boolean failed = infos.size() == 0 || failed_builds.size() > 0
+    if (failed) {
         failures = failed_builds.join(", ")
         emailbody = """
 $coverage_details
@@ -436,7 +438,7 @@ Logs: ${env.BUILD_URL}
         recipients = env.TEST_PASS_EMAIL_ADDRESS
     }
     subject = ((is_open_ci_env ? "TF Open CI" : "Internal CI") + " ${name} " + \
-           (failed_builds ? "failed" : "passed") + "! (branches: ${branches})")
+           (failed ? "failed" : "passed") + "! (branches: ${branches})")
     echo """\
 Subject: $subject
 

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -413,7 +413,7 @@ done
     )
 }
 
-void send_email(String name, Collection<BranchInfo> infos) {
+void maybe_send_email(String name, Collection<BranchInfo> infos) {
     String branches = infos*.branch.join(',')
     def failed_builds = infos.collectMany { info -> info.failed_builds}
     String coverage_details = infos.collect({info -> "$info.branch:\n$info.coverage_details"}).join('\n\n')

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -437,12 +437,17 @@ Logs: ${env.BUILD_URL}
     }
     subject = ((is_open_ci_env ? "TF Open CI" : "Internal CI") + " ${name} " + \
            (failed_builds ? "failed" : "passed") + "! (branches: ${branches})")
-    echo subject
-    echo emailbody
-    emailext body: emailbody,
-             subject: subject,
-             to: recipients,
-             mimeType: 'text/plain'
+    echo """\
+Subject: $subject
+
+$emailbody
+"""
+    if (recipients) {
+        emailext body: emailbody,
+                 subject: subject,
+                 to: recipients,
+                 mimeType: 'text/plain'
+    }
 }
 
 @NonCPS

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -418,9 +418,10 @@ void send_email(String name, Collection<BranchInfo> infos) {
     def failed_builds = infos.collectMany { info -> info.failed_builds}
     String coverage_details = infos.collect({info -> "$info.branch:\n$info.coverage_details"}).join('\n\n')
 
+    String emailbody, recipients
     boolean failed = infos.size() == 0 || failed_builds.size() > 0
     if (failed) {
-        failures = failed_builds.join(", ")
+        String failures = failed_builds.join(", ")
         emailbody = """
 $coverage_details
 
@@ -437,7 +438,7 @@ Logs: ${env.BUILD_URL}
 """
         recipients = env.TEST_PASS_EMAIL_ADDRESS
     }
-    subject = ((is_open_ci_env ? "TF Open CI" : "Internal CI") + " ${name} " + \
+    String subject = ((is_open_ci_env ? "TF Open CI" : "Internal CI") + " ${name} " + \
            (failed ? "failed" : "passed") + "! (branches: ${branches})")
     echo """\
 Subject: $subject

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -441,6 +441,7 @@ Logs: ${env.BUILD_URL}
     String subject = ((is_open_ci_env ? "TF Open CI" : "Internal CI") + " ${name} " + \
            (failed ? "failed" : "passed") + "! (branches: ${branches})")
     echo """\
+To: $recipients
 Subject: $subject
 
 $emailbody

--- a/vars/mbedtls-release-Jenkinsfile
+++ b/vars/mbedtls-release-Jenkinsfile
@@ -34,8 +34,8 @@
  *  - RUN_WINDOWS_TEST
  *
  * Other parameters
- *  - TEST_FAIL_EMAIL_ADDRESS - (only in nightly jobs)
- *  - TEST_PASS_EMAIL_ADDRESS - (only in nightly jobs)
+ *  - TEST_FAIL_EMAIL_ADDRESS
+ *  - TEST_PASS_EMAIL_ADDRESS
  *
  * Environment variables:
  *  - GIT_CREDENTIALS_ID

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -170,7 +170,7 @@ void run_release_job(String branches) {
 
 void run_release_job(List<String> branches) {
     analysis.main_record_timestamps('run_release_job') {
-        Map<String, BranchInfo> infos
+        Map<String, BranchInfo> infos = [:]
         try {
             environ.set_tls_release_environment()
             common.init_docker_images()
@@ -206,10 +206,7 @@ void run_release_job(List<String> branches) {
             stage('email-report') {
                 if (currentBuild.rawBuild.causes[0] instanceof ParameterizedTimerTriggerCause ||
                     currentBuild.rawBuild.causes[0] instanceof TimerTrigger.TimerTriggerCause) {
-                    common.send_email('Mbed TLS nightly tests',
-                                      infos.values(),
-                                      gen_jobs.coverage_details
-                    )
+                    common.send_email('Mbed TLS nightly tests', infos.values())
                 }
             }
         }

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -204,7 +204,13 @@ void run_release_job(List<String> branches) {
             }
         } finally {
             stage('email-report') {
-                common.maybe_send_email('Mbed TLS nightly tests', infos.values())
+                String type
+                if (currentBuild.rawBuild.getCause(TimerTrigger.TimerTriggerCause) != null) {
+                    type = 'nightly'
+                } else {
+                    type = 'release'
+                }
+                common.maybe_send_email("Mbed TLS $type tests", infos.values())
             }
         }
     }

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -204,10 +204,7 @@ void run_release_job(List<String> branches) {
             }
         } finally {
             stage('email-report') {
-                if (currentBuild.rawBuild.causes[0] instanceof ParameterizedTimerTriggerCause ||
-                    currentBuild.rawBuild.causes[0] instanceof TimerTrigger.TimerTriggerCause) {
-                    common.send_email('Mbed TLS nightly tests', infos.values())
-                }
+                common.send_email('Mbed TLS nightly tests', infos.values())
             }
         }
     }

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -204,7 +204,7 @@ void run_release_job(List<String> branches) {
             }
         } finally {
             stage('email-report') {
-                common.send_email('Mbed TLS nightly tests', infos.values())
+                common.maybe_send_email('Mbed TLS nightly tests', infos.values())
             }
         }
     }

--- a/vars/mbedtls.groovy
+++ b/vars/mbedtls.groovy
@@ -22,7 +22,6 @@ import hudson.model.Cause
 import hudson.model.Result
 import hudson.triggers.TimerTrigger
 import jenkins.model.CauseOfInterruption
-import org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTriggerCause
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 
 import org.mbed.tls.jenkins.BranchInfo


### PR DESCRIPTION
This call was missed / accidentally dropped during a rebase of commit 8d9b2b78df05a3bd0ef90e4cfe021373fc65c652.

Also initialize infos at declaration, so an early failure doesn't result in a null pointer dereference in the finally block.

Test runs:
- Internal CI
  - [E-mail set][1]
  - [E-mail unset][2]
- OpenCI
  - [E-mail set][3]

[1]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/727/
[2]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/728/
[3]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/287/