### PR TITLE
Enable Arm on-target testing on the OpenCI

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -70,8 +70,8 @@ import org.mbed.tls.jenkins.BranchInfo
 /* List of Linux platforms. When a job can run on multiple Linux platforms,
  * it runs on the first element of the list that supports this job. */
 @Field final List<String> linux_platforms =
-    ['ubuntu-16.04-amd64',  'ubuntu-18.04-amd64', 'ubuntu-20.04-amd64', 'ubuntu-22.04-amd64', 'arm-compilers-amd64'] +
-    (is_open_ci_env ? [] : ['ubuntu-18.04-arm64', 'ubuntu-20.04-arm64', 'ubuntu-22.04-arm64'])
+    ['ubuntu-16.04-amd64', 'ubuntu-18.04-amd64', 'ubuntu-20.04-amd64', 'ubuntu-22.04-amd64', 'arm-compilers-amd64',
+                           'ubuntu-18.04-arm64', 'ubuntu-20.04-arm64', 'ubuntu-22.04-arm64']
 /* List of BSD platforms. They all run freebsd_all_sh_components. */
 @Field bsd_platforms = ["freebsd"]
 
@@ -268,9 +268,6 @@ BranchInfo get_branch_information(String branch) {
                     ).trim().split('\n')
                     echo "All all.sh components: ${all.join(" ")}"
                     return all.collectEntries { element ->
-                        if (is_open_ci_env && element ==~ /test_(arm_linux_gnueabi|aarch64_linux_gnu).*/) {
-                            return [:]
-                        }
                         return [(element): null]
                     }
                 } else {


### PR DESCRIPTION
CI runs:
- release-ci-testing
  - [development][1]
  - [mbedtls-3.6][2]
  - [mbedtls-2.28][3]
  
[1]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/294/
[2]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/295/
[3]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/296/