### PR TITLE
Fix result analysis in failed multi-branch test runs

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -215,7 +215,7 @@ void gather_timestamps() {
 }
 
 void stash_outcomes(BranchInfo info, String job_name) {
-    def stash_name = job_name + '-outcome'
+    def stash_name = job_name.replace((char) '/', (char) '_') + '-outcome'
     if (findFiles(glob: '*-outcome.csv')) {
         stash(name: stash_name,
               includes: '*-outcome.csv',
@@ -237,8 +237,10 @@ void  analyze_results(Collection<BranchInfo> infos) {
 
         String prefix = infos.size() > 1 ? "$info.branch-" : ''
         String job_name = "${prefix}result-analysis"
-        String outcomes_csv = "${prefix}outcomes.csv"
-        String failures_csv = "${prefix}failures.csv"
+
+        String file_prefix = prefix.replace((char) '/', (char) '_')
+        String outcomes_csv = "${file_prefix}outcomes.csv"
+        String failures_csv = "${file_prefix}failures.csv"
 
         Closure post_checkout = {
             dir('csvs') {

--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -258,7 +258,7 @@ void  analyze_results(Collection<BranchInfo> infos) {
             // as test description or test suite was "FAIL".
             if (info.failed_builds) {
                 sh """\
-LC_ALL=C grep ';FAIL;' outcomes.csv >'$failures_csv' || [ \$? -eq 1 ]
+LC_ALL=C grep ';FAIL;' $outcomes_csv >'$failures_csv' || [ \$? -eq 1 ]
 # Compress the failure list if it is large (for some value of large)
 if [ "\$(wc -c <'$failures_csv')" -gt 99999 ]; then
     xz -0 -T0 '$failures_csv'

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -199,6 +199,7 @@ def gen_all_sh_jobs(BranchInfo info, platform, component, label_prefix='') {
     /* Default to the full platform hame is a shorthand is not found */
     def shortplat = shorthands.getOrDefault(platform, platform)
     def job_name = "${label_prefix}all_${shortplat}-${component}"
+    def outcome_file = "${job_name.replace((char) '/', (char) '_')}-outcome.csv"
     def use_docker = platform_has_docker(platform)
     def extra_setup_code = ''
     def node_label = node_label_for_platform(platform)
@@ -262,7 +263,7 @@ scripts/min_requirements.py --user ${info.python_requirements_override_file}
 #!/bin/sh
 set -eux
 ulimit -f 20971520
-export MBEDTLS_TEST_OUTCOME_FILE='${job_name}-outcome.csv'
+export MBEDTLS_TEST_OUTCOME_FILE='$outcome_file'
 ${extra_setup_code}
 ./tests/scripts/all.sh --seed 4 --keep-going $component
 """


### PR DESCRIPTION
This PR fixes several issues that occur when the name of the Mbed TLS branch being tested is included in file or stash names. This happens when we test multiple branches at once, eg. in framework PRs or if multiple branches are specified in a parameterized job.

In addition, the second commit breaks gen_docker_job into sub-stages, so that the result analysis display on Blue ocean is not overwhelmed by the unstash stages. 

Fixes #127 

Test runs:
 - development: good + skipped/failed tests
   - [Internal CI][1]
   - [OpenCI][2]
 - development: release job
   - [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/297/)
 
[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/372/
[2]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/64/