### PR TITLE
Make readme work

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Assuming `<mount dir>` is the root of an Mbed TLS source tree, first install the
 ```sh
 ./scripts/min_requirements.py --user
 ```
+(This will install packages in the `.local` subdirectory of `<mount dir>`.)
+Don't worry about the warnings about `.local/bin` not being on `PATH`, our
+tests will not rely on the executables but instead use `python -m xxx`.
+
 Then the tests can be run with:
 ```sh
 ./tests/scripts/all.sh

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The docker files in `resources/docker_files` are the ones used by the CI. For mo
 
 To get the docker image used in the CI, run the following command from the root of a fresh checkout of the `master` branch of this repository:
 ```sh
-docker pull trustedfirmware/ci-amd64-mbed-tls-ubuntu:ubuntu-16.04-$(git hash-object resources/docker_files/ubuntu-16.04/Dockerfile)
+docker pull trustedfirmware/ci-amd64-mbed-tls-ubuntu:ubuntu-16.04-$(git hash-object resources/docker_files/ubuntu-16.04/Dockerfile)-amd64
 ```
 Then to run the image:
 ```sh
-./resources/docker_files/run.sh <mount dir> trustedfirmware/ci-amd64-mbed-tls-ubuntu:ubuntu-16.04-$(git hash-object resources/docker_files/ubuntu-16.04/Dockerfile)
+./resources/docker_files/run.sh <mount dir> trustedfirmware/ci-amd64-mbed-tls-ubuntu:ubuntu-16.04-$(git hash-object resources/docker_files/ubuntu-16.04/Dockerfile)-amd64
 ```
 Where `<mount dir>` is a directory from the host that will be mounted on the container at startup (usually a local checkout of Mbed TLS).
 

--- a/resources/docker_files/README.md
+++ b/resources/docker_files/README.md
@@ -33,7 +33,6 @@ The helper script `run.sh` can be used to launch a docker image:
 ```
 `run.sh` makes it easier to start images with a suitable working environment. It:
 - mounts a local directory on to the container at startup. Hence, a local checkout of Mbed TLS can be used and artefacts produced can be preserved even after exiting the image.
-- mounts `~/.ssh` directory to the docker home so that `git` can be used from within the docker.
 - configures user ids for the docker user to be same as the host user to preserve the permissions on the files created or modified inside the docker.
 
 ## Running the images manually

--- a/resources/docker_files/list-docker-image-tags.sh
+++ b/resources/docker_files/list-docker-image-tags.sh
@@ -10,7 +10,11 @@ list () {
     dir="${1%/Dockerfile}"
     dir="${dir%/}"
     hash="$(git hash-object "$dir/Dockerfile")"
-    echo "$(basename -- "$dir")-$hash"
+    base="$(basename -- "$dir")"
+    echo "$base-$hash-amd64"
+    if [ "$base" != "arm-compilers" ]; then
+        echo "$base-$hash-arm64"
+    fi
 }
 
 if [ $# -eq 0 ]; then

--- a/resources/docker_files/run.sh
+++ b/resources/docker_files/run.sh
@@ -56,5 +56,5 @@ echo "  Mounting $SSH_CFG_PATH --> /home/user/.ssh"
 echo "  Mounting $MOUNT_DIR --> /var/lib/ws"
 echo "****************************************************"
 
-sudo docker run --network=host --rm -i -t -u $USR_ID:$USR_GRP -w /var/lib/ws -v $MOUNT_DIR:/var/lib/ws -v $SSH_CFG_PATH:/home/user/.ssh --cap-add SYS_PTRACE ${IMAGE}
+sudo docker run --network=host --rm -i -t -u $USR_ID:$USR_GRP -w /var/lib/ws -e HOME=/var/lib/ws -v $MOUNT_DIR:/var/lib/ws -v $SSH_CFG_PATH:/home/user/.ssh --cap-add SYS_PTRACE ${IMAGE}
 

--- a/resources/docker_files/run.sh
+++ b/resources/docker_files/run.sh
@@ -26,8 +26,6 @@
 #               created/updated by docker image can be accessible after
 #               exiting the image.
 #   Mount dir   Mounts a user specified dir to the working dir in the image.
-#   Mount ~/.ssh Also mounts host's ~/.ssh to ~/.ssh
-#               in the image. So git can be used.
 #
 # Usage: ./run.sh mount_dir docker_image_tag
 #
@@ -47,14 +45,12 @@ IMAGE=$2
 USR_NAME=`id -un`
 USR_ID=`id -u`
 USR_GRP=`id -g`
-SSH_CFG_PATH=~/.ssh
 
 echo "****************************************************"
 echo "  Running docker image - $IMAGE"
 echo "  User ID:Group ID --> $USR_ID:$USR_GRP"
-echo "  Mounting $SSH_CFG_PATH --> /home/user/.ssh"
 echo "  Mounting $MOUNT_DIR --> /var/lib/ws"
 echo "****************************************************"
 
-sudo docker run --network=host --rm -i -t -u $USR_ID:$USR_GRP -w /var/lib/ws -e HOME=/var/lib/ws -v $MOUNT_DIR:/var/lib/ws -v $SSH_CFG_PATH:/home/user/.ssh --cap-add SYS_PTRACE ${IMAGE}
+sudo docker run --network=host --rm -i -t -u $USR_ID:$USR_GRP -w /var/lib/ws -e HOME=/var/lib/ws -v $MOUNT_DIR:/var/lib/ws --cap-add SYS_PTRACE ${IMAGE}
 


### PR DESCRIPTION
Before this PR, if one tries to follow this repo's top-level Readme, things will fail in two places:

1. `scripts/min_requirement.py --user` fails with permission issues. This has been the case for a long time. Fixed by changing `run.sh`.
2. `docker pull` fails. This is new since the tags now include the architecture. Fixed by updating the Readme.
