### PR TITLE
Use a venv for min_requirements.py on Linux and FreeBSD

### DIFF
--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -92,6 +92,8 @@ RUN apt-get update -q && apt-get install -yq \
         locales \
         # to install several Python packages (done by individual jobs)
         python3-pip \
+        # to install several Python packages (done by individual jobs)
+        python3-venv \
     && rm -rf /var/lib/apt/lists/
 
 # Install Python pip packages

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -83,8 +83,10 @@ RUN apt-get update -q && apt-get install -yq \
         make \
         # to build GnuTLS with locally-compiled nettle
         pkg-config \
-        # to install the preferred version of pylint
+        # to install several Python packages (done by individual jobs)
         python3-pip \
+        # to install several Python packages (done by individual jobs)
+        python3-venv \
         # for Mbed TLS tests
         valgrind \
         # to download things installed from other places

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -91,6 +91,8 @@ RUN apt-get update -q && apt-get install -yq \
         pkg-config \
         # to install several Python packages (done by individual jobs)
         python3-pip \
+        # to install several Python packages (done by individual jobs)
+        python3-venv \
         # for Mbed TLS tests
         valgrind \
         # to download things installed from other places

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -97,8 +97,10 @@ RUN apt-get update -q && apt-get install -yq \
         make \
         # to build GnuTLS with locally-compiled nettle
         pkg-config \
-        # to install Python packages
+        # to install several Python packages (done by individual jobs)
         python3-pip \
+        # to install several Python packages (done by individual jobs)
+        python3-venv \
         # provides some useful scripts for adding and removing repositories
         software-properties-common \
         # for Mbed TLS tests

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -142,7 +142,9 @@ set -eux
 ulimit -f 20971520
 
 if [ -e scripts/min_requirements.py ]; then
-scripts/min_requirements.py --user ${info.python_requirements_override_file}
+python3 -m venv --system-site-packages --without-pip venv
+export PATH="\$PWD/venv/bin:\$PATH"
+python3 scripts/min_requirements.py ${info.python_requirements_override_file}
 fi
 """ + script_in_docker
                     sh 'chmod +x steps.sh'
@@ -247,7 +249,9 @@ echo >&2 'Note: "clang" will run /usr/bin/clang -Wno-error=c11-extensions'
 
     if (info.has_min_requirements) {
         extra_setup_code += """
-scripts/min_requirements.py --user ${info.python_requirements_override_file}
+python3 -m venv --system-site-packages --without-pip venv
+export PATH="\$PWD/venv/bin:\$PATH"
+scripts/min_requirements.py ${info.python_requirements_override_file}
 """
     }
 

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -251,7 +251,7 @@ echo >&2 'Note: "clang" will run /usr/bin/clang -Wno-error=c11-extensions'
         extra_setup_code += """
 python3 -m venv --system-site-packages --without-pip venv
 export PATH="\$PWD/venv/bin:\$PATH"
-scripts/min_requirements.py ${info.python_requirements_override_file}
+python3 scripts/min_requirements.py ${info.python_requirements_override_file}
 """
     }
 


### PR DESCRIPTION
Use a python virtual environment when installing pip packages via min_requirements.py. This prevents the installed packages from interfering with the host system.

It also works around spurious build failures when installing said packages. Fixes https://github.com/Mbed-TLS/mbedtls-test/issues/194

Test runs:
- development
  - Internal CI
    - [mbed-tls-pr-test-parametrized][1]
  - Open CI
    - [mbed-tls-restricted-pr-test-parametrized][2] 
  
[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/448/
[2]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/96/