### PR TITLE
Update OPENSSL_NEXT to what 3.6 and development use

### DIFF
--- a/resources/docker_files/ubuntu-16.04/Dockerfile
+++ b/resources/docker_files/ubuntu-16.04/Dockerfile
@@ -215,8 +215,6 @@ RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
 ENV OPENSSL_1_1_1=/usr/local/openssl-1.1.1a/bin/openssl
 ENV OPENSSL_1_1=/usr/local/openssl-1.1.1a/bin/openssl
 ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
-# Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 RUN wget -q https://www.openssl.org/source/openssl-3.0.10.tar.gz && \
     tar -zxf openssl-3.0.10.tar.gz && cd openssl-3.0.10 && \
@@ -234,6 +232,14 @@ RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
 ENV OPENSSL_3_1_2=/usr/local/openssl-3.1.2/bin/openssl
 ENV OPENSSL_3_1=/usr/local/openssl-3.1.2/bin/openssl
 ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
+# As of early 2025 (just after 2.28 became EOL), 3.6 and development both:
+# - set OPENSSL_NEXT to OPENSSL_3 (if OPENSSL_3 is defined) in all-core.sh,
+#   effectively ignoring the value of OPENSSL_NEXT from the environment;
+# - but use OPENSSL_NEXT straight from the environment in basic-build-test.sh,
+#   (both directly, and indirectly when invoking ssl-opt.sh which uses it).
+# So, we still need to set OPENSSL_NEXT here. (The long-term plan is that
+# scripts should be updated to only use explicit versions like OPENSSL_3.)
+ENV OPENSSL_NEXT=/usr/local/openssl-3.1.2/bin/openssl
 
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each

--- a/resources/docker_files/ubuntu-18.04/Dockerfile
+++ b/resources/docker_files/ubuntu-18.04/Dockerfile
@@ -191,8 +191,6 @@ RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
 ENV OPENSSL_1_1_1=/usr/local/openssl-1.1.1a/bin/openssl
 ENV OPENSSL_1_1=/usr/local/openssl-1.1.1a/bin/openssl
 ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
-# Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 RUN wget -q https://www.openssl.org/source/openssl-3.0.10.tar.gz && \
     tar -zxf openssl-3.0.10.tar.gz && cd openssl-3.0.10 && \
@@ -210,6 +208,14 @@ RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
 ENV OPENSSL_3_1_2=/usr/local/openssl-3.1.2/bin/openssl
 ENV OPENSSL_3_1=/usr/local/openssl-3.1.2/bin/openssl
 ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
+# As of early 2025 (just after 2.28 became EOL), 3.6 and development both:
+# - set OPENSSL_NEXT to OPENSSL_3 (if OPENSSL_3 is defined) in all-core.sh,
+#   effectively ignoring the value of OPENSSL_NEXT from the environment;
+# - but use OPENSSL_NEXT straight from the environment in basic-build-test.sh,
+#   (both directly, and indirectly when invoking ssl-opt.sh which uses it).
+# So, we still need to set OPENSSL_NEXT here. (The long-term plan is that
+# scripts should be updated to only use explicit versions like OPENSSL_3.)
+ENV OPENSSL_NEXT=/usr/local/openssl-3.1.2/bin/openssl
 
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each

--- a/resources/docker_files/ubuntu-20.04/Dockerfile
+++ b/resources/docker_files/ubuntu-20.04/Dockerfile
@@ -189,8 +189,6 @@ RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
 ENV OPENSSL_1_1_1=/usr/local/openssl-1.1.1a/bin/openssl
 ENV OPENSSL_1_1=/usr/local/openssl-1.1.1a/bin/openssl
 ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
-# Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 RUN wget -q https://www.openssl.org/source/openssl-3.0.10.tar.gz && \
     tar -zxf openssl-3.0.10.tar.gz && cd openssl-3.0.10 && \
@@ -208,6 +206,14 @@ RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
 ENV OPENSSL_3_1_2=/usr/local/openssl-3.1.2/bin/openssl
 ENV OPENSSL_3_1=/usr/local/openssl-3.1.2/bin/openssl
 ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
+# As of early 2025 (just after 2.28 became EOL), 3.6 and development both:
+# - set OPENSSL_NEXT to OPENSSL_3 (if OPENSSL_3 is defined) in all-core.sh,
+#   effectively ignoring the value of OPENSSL_NEXT from the environment;
+# - but use OPENSSL_NEXT straight from the environment in basic-build-test.sh,
+#   (both directly, and indirectly when invoking ssl-opt.sh which uses it).
+# So, we still need to set OPENSSL_NEXT here. (The long-term plan is that
+# scripts should be updated to only use explicit versions like OPENSSL_3.)
+ENV OPENSSL_NEXT=/usr/local/openssl-3.1.2/bin/openssl
 
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -322,6 +322,9 @@ RUN python3 -m pip config set global.progress_bar off && \
     python3 -m pip install setuptools --upgrade && \
     true
 
+#Upgrade pip to the latest version
+RUN  python3 -m pip install --upgrade pip
+
 # Make sure we have a UTF-8 locale
 RUN locale && \
     locale-gen "en_US.UTF-8" && \

--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -227,8 +227,6 @@ RUN wget -q https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
 ENV OPENSSL_1_1_1=/usr/local/openssl-1.1.1a/bin/openssl
 ENV OPENSSL_1_1=/usr/local/openssl-1.1.1a/bin/openssl
 ENV OPENSSL_1=/usr/local/openssl-1.1.1a/bin/openssl
-# Up to at least 2023, the test scripts expect that $OPENSSL_NEXT is 1.1.1a.
-ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
 
 RUN wget -q https://www.openssl.org/source/openssl-3.0.10.tar.gz && \
     tar -zxf openssl-3.0.10.tar.gz && cd openssl-3.0.10 && \
@@ -246,6 +244,14 @@ RUN wget -q https://www.openssl.org/source/openssl-3.1.2.tar.gz && \
 ENV OPENSSL_3_1_2=/usr/local/openssl-3.1.2/bin/openssl
 ENV OPENSSL_3_1=/usr/local/openssl-3.1.2/bin/openssl
 ENV OPENSSL_3=/usr/local/openssl-3.1.2/bin/openssl
+# As of early 2025 (just after 2.28 became EOL), 3.6 and development both:
+# - set OPENSSL_NEXT to OPENSSL_3 (if OPENSSL_3 is defined) in all-core.sh,
+#   effectively ignoring the value of OPENSSL_NEXT from the environment;
+# - but use OPENSSL_NEXT straight from the environment in basic-build-test.sh,
+#   (both directly, and indirectly when invoking ssl-opt.sh which uses it).
+# So, we still need to set OPENSSL_NEXT here. (The long-term plan is that
+# scripts should be updated to only use explicit versions like OPENSSL_3.)
+ENV OPENSSL_NEXT=/usr/local/openssl-3.1.2/bin/openssl
 
 # GnuTLS has a number of (optional) dependencies:
 # - nettle (crypto library): quite tighly coupled, so build one for each


### PR DESCRIPTION
3.6 and development want `OPENSSL_NEXT` to be 3.1.2.

In `all.sh` this is forced, but not in `basic-build-test.sh` (used by the coverage part of the release job), or when invoking `ssl-opt.sh` directly (which does not happen on the CI but might when using the Docker images for debugging).

As a result, `basic-build-test.sh` has been failing in the 3.6 release CI (because the new tests crucially rely on `OPENSSL_NEXT` being 3.x).

This can be fixed by updating `OPENSSL_NEXT` in the docker images. We couldn't do it previously because 2.28 was still relying on it being 1.1.1a, but now that 2.28 is EOL we're finally free.

(Note that in the long run, the plan is to no longer set `OPENSSL_NEXT` or `OPENSSL_LEGACY` in the Docker files. But first we need to update all script to use named version variables like `OPENSSL_3` - and then make a release - and only then we can remove the variables from the Dockerfiles.)

Test builds:
- development:  https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/793
- 3.6: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/794/