### PR TITLE
Switch MSVC builds to Visual Studio 2017

### DIFF
--- a/resources/windows/windows_testing.py
+++ b/resources/windows/windows_testing.py
@@ -471,7 +471,7 @@ class MbedWindowsTesting(object):
         elif c89:
             retarget = "Windows7.1SDK"  # Workaround for missing 2010 x64 tools
         else:
-            retarget = "v120" # Visual Studio 2013
+            retarget = "v150" # Visual Studio 2017
         logger.info("retarget={}".format(retarget))
         for solution_file in os.listdir(solution_dir):
             if re.match(self.solution_file_pattern, solution_file):

--- a/resources/windows/windows_testing.py
+++ b/resources/windows/windows_testing.py
@@ -471,7 +471,7 @@ class MbedWindowsTesting(object):
         elif c89:
             retarget = "Windows7.1SDK"  # Workaround for missing 2010 x64 tools
         else:
-            retarget = "v150" # Visual Studio 2017
+            retarget = "v141" # Visual Studio 2017
         logger.info("retarget={}".format(retarget))
         for solution_file in os.listdir(solution_dir):
             if re.match(self.solution_file_pattern, solution_file):

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -376,11 +376,9 @@ void check_every_all_sh_component_will_be_run(Collection<BranchInfo> infos) {
 
 def get_supported_windows_builds() {
     def vs_builds = []
-    if (env.JOB_TYPE == 'PR') {
-        vs_builds = ['2013']
-    } else {
-        vs_builds = ['2013', '2017']
-    }
+    /* At the time of writing, all supported branches (3.6, development)
+     * advertise support for Visual Studio 2017 (VS 15.0) and above. */
+    vs_builds = ['2017']
     echo "vs_builds = ${vs_builds}"
     return ['mingw'] + vs_builds
 }

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -439,12 +439,12 @@ def gen_windows_jobs(BranchInfo info, String label_prefix='') {
         preamble + scripts.win32_mingw_test_bat
     )
     jobs = jobs + gen_simple_windows_jobs(
-        info, label_prefix + 'win32_msvc12_32',
-        preamble + scripts.win32_msvc12_32_test_bat
+        info, label_prefix + 'win32_msvc15_32',
+        preamble + scripts.win32_msvc15_32_test_bat
     )
     jobs = jobs + gen_simple_windows_jobs(
-        info, label_prefix + 'win32-msvc12_64',
-        preamble + scripts.win32_msvc12_64_test_bat
+        info, label_prefix + 'win32-msvc15_64',
+        preamble + scripts.win32_msvc15_64_test_bat
     )
     for (build in common.get_supported_windows_builds()) {
         jobs = jobs + gen_windows_testing_job(info, build, label_prefix)

--- a/vars/scripts.groovy
+++ b/vars/scripts.groovy
@@ -37,20 +37,20 @@ cmake -D CMAKE_BUILD_TYPE:String=Check -G "MinGW Makefiles" . || exit
 mingw32-make lib || exit
 '''
 
-@Field static final String win32_msvc12_32_test_bat = '''\
-call "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" || exit
+@Field static final String win32_msvc15_32_test_bat = '''\
+call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
-cmake . -G "Visual Studio 12" || exit
+cmake . -G "Visual Studio 15 2017" -A Win32 || exit
 MSBuild ALL_BUILD.vcxproj || exit
 programs\\test\\Debug\\selftest.exe || exit
 '''
 
-@Field static final String win32_msvc12_64_test_bat = '''\
-call "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" || exit
+@Field static final String win32_msvc15_64_test_bat = '''\
+call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
-cmake . -G "Visual Studio 12 Win64" || exit
+cmake . -G "Visual Studio 15 2017" -A x64 || exit
 MSBuild ALL_BUILD.vcxproj || exit
 programs\\test\\Debug\\selftest.exe || exit
 '''

--- a/vars/scripts.groovy
+++ b/vars/scripts.groovy
@@ -38,7 +38,7 @@ mingw32-make lib || exit
 '''
 
 @Field static final String win32_msvc15_32_test_bat = '''\
-call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" || exit
+call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat x86" || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 15 2017" -A Win32 || exit
@@ -47,7 +47,7 @@ programs\\test\\Debug\\selftest.exe || exit
 '''
 
 @Field static final String win32_msvc15_64_test_bat = '''\
-call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" || exit
+call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat x64" || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 15 2017" -A x64 || exit

--- a/vars/scripts.groovy
+++ b/vars/scripts.groovy
@@ -38,6 +38,7 @@ mingw32-make lib || exit
 '''
 
 @Field static final String win32_msvc15_32_test_bat = '''\
+set VSCMD_START_DIR=%cd%
 call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86 || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
@@ -47,6 +48,7 @@ programs\\test\\Debug\\selftest.exe || exit
 '''
 
 @Field static final String win32_msvc15_64_test_bat = '''\
+set VSCMD_START_DIR=%cd%
 call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64 || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit

--- a/vars/scripts.groovy
+++ b/vars/scripts.groovy
@@ -38,7 +38,7 @@ mingw32-make lib || exit
 '''
 
 @Field static final String win32_msvc15_32_test_bat = '''\
-call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat x86" || exit
+call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86 || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 15 2017" -A Win32 || exit
@@ -47,7 +47,7 @@ programs\\test\\Debug\\selftest.exe || exit
 '''
 
 @Field static final String win32_msvc15_64_test_bat = '''\
-call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat x64" || exit
+call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64 || exit
 set CC=cl
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "Visual Studio 15 2017" -A x64 || exit

--- a/vars/scripts.groovy
+++ b/vars/scripts.groovy
@@ -20,6 +20,10 @@
 import groovy.transform.Field
 
 @Field static final String win32_mingw_test_bat = '''\
+perl --version
+python --version
+cmake --version
+mingw32-make --version
 set CC=gcc
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 cmake . -G "MinGW Makefiles" || exit
@@ -30,6 +34,10 @@ programs\\test\\selftest.exe || exit
 '''
 
 @Field static final String iar8_mingw_test_bat = '''\
+perl --version
+python --version
+cmake --version
+iccarm --version
 set CC=iccarm
 if exist scripts\\make_generated_files.bat call scripts\\make_generated_files.bat || exit
 perl scripts/config.pl baremetal || exit
@@ -38,6 +46,9 @@ mingw32-make lib || exit
 '''
 
 @Field static final String win32_msvc15_32_test_bat = '''\
+perl --version
+python --version
+cmake --version
 set VSCMD_START_DIR=%cd%
 call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x86 || exit
 set CC=cl
@@ -48,6 +59,9 @@ programs\\test\\Debug\\selftest.exe || exit
 '''
 
 @Field static final String win32_msvc15_64_test_bat = '''\
+perl --version
+python --version
+cmake --version
 set VSCMD_START_DIR=%cd%
 call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64 || exit
 set CC=cl


### PR DESCRIPTION
Resolves https://github.com/Mbed-TLS/mbedtls-test/issues/202. Also resolves https://github.com/Mbed-TLS/mbedtls-test/issues/27.

Scope: I've deliberately made a minimal set of changes. There are probably many simplifications we can make, but that was already the case before (we stil have code related to branches older than 2.18 when we didn't require a C99 compiler!). The current setup is simpler than it might become in the future, however, because currently it's fine to test all branches against the same VS version, but there will probably be times when we want different versions in LTS branches.

Test jobs:
* [release job, mbedtls/development, OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/358/) → looks ok to me (passed and seems to have used the intended VS version throughout)
* [release job, mbedtls/development, internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/798/) → looks ok to me (passed and seems to have used the intended VS version throughout)
