### PR TITLE
Update GCC 15 snapshot to the 15.1.0 release

### DIFF
--- a/resources/docker_files/ubuntu-22.04/Dockerfile
+++ b/resources/docker_files/ubuntu-22.04/Dockerfile
@@ -187,15 +187,15 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
 # Eventually, gcc-latest should become GCC 15. This will cause test failures
 # on branches that don't have the fix yet, which is why we don't make
 # GCC 15 be gcc-latest immediately.
-RUN wget -q https://mirror.koddos.net/gcc/snapshots/15-20241201/gcc-15-20241201.tar.xz && \
-    tar -xf gcc-15-20241201.tar.xz && \
-    rm gcc-15-20241201.tar.xz && \
-    cd gcc-15-20241201 && \
+RUN wget -q https://mirror.koddos.net/gcc/releases/gcc-15.1.0/gcc-15.1.0.tar.xz && \
+    tar -xf gcc-15.1.0.tar.xz && \
+    rm gcc-15.1.0.tar.xz && \
+    cd gcc-15.1.0 && \
     ./configure --prefix=/usr/local/gcc-15 --program-suffix=-15 --disable-bootstrap --enable-languages=c,c++,lto && \
     make && \
     make install && \
     cd .. && \
-    rm -rf gcc-15-20241201
+    rm -rf gcc-15.1.0
 
 # Install exact upstream versions of OpenSSL and GnuTLS
 #


### PR DESCRIPTION
Now that [GCC 15 is released](https://gcc.gnu.org/gcc-15/changes.html), upgrade to the official release. Let's not keep a development snapshot any longer than we have to.

I'm still building from source because there are no official packages either from GNU (as a habit, they only distribute sources) or from Ubuntu ([Ubuntu have some toolchain previews](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test), but they don't backport to older releases).

(As a reminder, we have GCC 15 in our CI because [it revealed a high-impact bug in our code](https://github.com/Mbed-TLS/mbedtls/issues/9814).)

Test jobs (on https://github.com/Mbed-TLS/mbedtls/pull/10159):
* [internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/803/)
* [OpenCI](https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/360/)
