### PR TITLE
Prevent git warnings during normal testing flow

### DIFF
--- a/vars/checkout_repo.groovy
+++ b/vars/checkout_repo.groovy
@@ -154,8 +154,11 @@ Map<String, String> checkout_tls_repo(BranchInfo info) {
 
     def result = checkout_report_errors(scm_config)
 
-    dir('tf-psa-crypto') {
-        checkout_tf_psa_crypto_repo(info)
+    // Do not attempt to clone tf-psa-crypto if the submodule is not present (mbedtls-3.6)
+    if (get_submodule_commit('tf-psa-crypto')) {
+        dir('tf-psa-crypto') {
+            checkout_tf_psa_crypto_repo(info)
+        }
     }
 
     dir('framework') {

--- a/vars/checkout_repo.groovy
+++ b/vars/checkout_repo.groovy
@@ -80,15 +80,10 @@ Map<String, String> try_checkout_from_repos(List<String> maybe_repos, String bra
 }
 
 String get_submodule_commit(String working_dir = '.', String submodule) {
-    try {
-        return sh(
-            script: "git -C $working_dir rev-parse HEAD:$submodule",
-            returnStdout: true
-        ).trim()
-    } catch (AbortException e) {
-        echo e.message
-        return ''
-    }
+    return sh(
+        script: "sha=\$(git -C '$working_dir' rev-parse 'HEAD:$submodule') && echo \"\$sha\" || true",
+        returnStdout: true
+    ).trim()
 }
 
 void checkout_framework_repo(BranchInfo info) {


### PR DESCRIPTION
This PR prevents / silences the warnings in the normal testing flow introduced by #206 

Test runs:
- mbedtls-3.6: PR-head
    - [OpenCI][1]
    - [Internal CI][2]
- development: PR-head
    - [OpenCI][3]
    - [Internal CI][4]

    
[1]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-1233-head/20/
[2]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/job/PR-1233-head/24/
[3]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-ci-testing/view/change-requests/job/PR-906-head/49/
[4]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-ci-testing/view/change-requests/job/PR-906-head/144/