### PR TITLE
Disable ipv6 networking inside docker

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -214,6 +214,12 @@ String docker_script(
 ) {
     def docker_image = get_docker_tag(platform)
     def env_args = env_vars.collect({ e -> "-e $e" }).join(' ')
+    /* Docker disables IPv6 networking by default, but some combination of docker daemon and linux kernel versions
+     * causes GnuTLS to attempt using an IPv6 address anyways, so we manually disable all IPv6 inside the container.
+     * We also ignore the fact that the IPv6 tests are not executed in analyze_outcomes.py.
+     * Once we have configured docker to enable IPv6 networking, this workaround should be removed.
+     * See: Mbed-TLS/mbedtls-test#176 and Mbed-TLS/mbedtls-test#213
+     */
     return """\
 docker run -u \$(id -u):\$(id -g) -e MAKEFLAGS -e VERBOSE_LOGS $env_args --rm --entrypoint $entrypoint \
     -w /var/lib/build -v `pwd`/src:/var/lib/build \

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -217,6 +217,7 @@ String docker_script(
     return """\
 docker run -u \$(id -u):\$(id -g) -e MAKEFLAGS -e VERBOSE_LOGS $env_args --rm --entrypoint $entrypoint \
     -w /var/lib/build -v `pwd`/src:/var/lib/build \
+    --sysctl net.ipv6.conf.all.disable_ipv6=1 \
     --cap-add SYS_PTRACE $docker_repo:$docker_image $entrypoint_arguments
 """
 }


### PR DESCRIPTION
Workaround for https://github.com/Mbed-TLS/mbedtls-test/issues/213

Combined test runs with Mbed-TLS/mbedtls#10302:
- [Open CI](https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/164/)
- [Internal CI](https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/516/)