### PR TITLE
Add coverity push script for 3.6

### DIFF
--- a/coverity/push_coverity_scan.py
+++ b/coverity/push_coverity_scan.py
@@ -117,7 +117,7 @@ def backup_config_files(logger: logging.Logger, mbedtls_dir: pathlib.Path, resto
     backup_config_file(logger, config_path, restore)
 
     config_path = pathlib.Path(mbedtls_dir)
-    config_path = config_path / 'tf-psa-crypto' / 'include' / 'psa' / 'crypto_config.h'
+    config_path = config_path / 'include' / 'psa' / 'crypto_config.h'
 
     backup_config_file(logger, config_path, restore)
 


### PR DESCRIPTION
A tweaked version of #165 that allows pushing builds for the `mbedtls-3.6` branch (rather than `development` as was happening before).