### PR TITLE
Fix priority inversion in init-docker-images stage

### DIFF
--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -713,6 +713,9 @@ def gen_dockerfile_builder_job(String platform, boolean overwrite=false) {
             /* Take the lock only once we are running on a node.
              * This prevents a low-priority job from hogging the lock, when a high-priority job (eg. a merge queue job)
              * is added to the queue later.
+             * The locking order may be reverted to (lock -> node) once we transition to using a dedicated node label
+             * for building arm64 dockerfiles instead of container-host-arm64 (see the definition of node_label above),
+             * as this would reduce contention for the nodes enough to eliminate concerns about the priority inversion.
              */
             lock(tag) {
                 def image_exists = false


### PR DESCRIPTION
Taking the lock before we are running on a node is preventing the priority sorter from properly prioritizing merge-queue jobs.
Invert the order of taking the "locks" (node -> docker-image), to fix this priority inversion.

Test runs (#216 cherry-picked on top of #212) :
- development
  - [Internal CI][1]
  - [Open CI][2]

**PLEASE NOTE**: Care should be taken when merging this PR, since the interaction between runs that still use the old CI scripts (eg. started before the merge) and new runs could cause a deadlock. It would be best to merge it in a quiet period on the CI.

[1]: https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-test-parametrized/518/
[2]: https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/164/