### PR TITLE
Disable Windows tests using legacy build systems if they are not supported by the tested branch

### DIFF
--- a/src/org/mbed/tls/jenkins/BranchInfo.groovy
+++ b/src/org/mbed/tls/jenkins/BranchInfo.groovy
@@ -54,8 +54,11 @@ class BranchInfo {
     /** All of the Visual Studio versions supported by this branch */
     public List<String> supported_vs_versions
 
-    /** Whether this branch supports builds using legacy, non-CMake build systems */
-    boolean supports_legacy_build_systems
+    /** Whether this branch has shipped Makefiles */
+    public boolean has_shipped_makefiles
+
+    /** Whether this branch has shipped Visual Studio solution files */
+    public boolean has_shipped_vs_solutions
 
     /** Keep track of builds that fail */
     final Set<String> failed_builds
@@ -73,7 +76,8 @@ class BranchInfo {
         this.python_requirements_override_content = ''
         this.python_requirements_override_file = ''
         this.supported_vs_versions = []
-        this.supports_legacy_build_systems = false
+        this.has_shipped_makefiles = false
+        this.has_shipped_vs_solutions = false
         this.failed_builds = []
         this.outcome_stashes = []
         this.coverage_details = 'Code coverage job did not run'

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -277,7 +277,8 @@ List<BranchInfo> get_branch_information(Collection<String> tls_branches, Collect
                             info.supported_vs_versions = ['2017']
 
                             // Detect support for legacy build systems (< Mbed TLS 4.0)
-                            info.supports_legacy_build_systems = fileExists('Makefile')
+                            info.has_shipped_makefiles    = fileExists('Makefile')
+                            info.has_shipped_vs_solutions = fileExists('visualc/VS2017')
                         }
 
                         String platform = linux_platforms[0]

--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -321,7 +321,7 @@ def gen_windows_testing_job(BranchInfo info, String toolchain) {
     def prefix = "${info.prefix}Windows-${toolchain}"
     def build_configs, arches, build_systems, retargeted
     if (toolchain == 'mingw') {
-        if (!info.supports_legacy_build_systems) {
+        if (!info.has_shipped_makefiles) {
             // The mingw toolchain uses the legacy shipped Makefiles
             return [:]
         }
@@ -332,7 +332,7 @@ def gen_windows_testing_job(BranchInfo info, String toolchain) {
     } else {
         build_configs = ['Release', 'Debug']
         arches = ['Win32', 'x64']
-        build_systems = info.supports_legacy_build_systems ? ['shipped', 'cmake'] : ['cmake']
+        build_systems = info.has_shipped_vs_solutions ? ['shipped', 'cmake'] : ['cmake']
         retargeted = [false, true]
     }
 


### PR DESCRIPTION
Fixes Mbed-TLS/mbedtls#10144

This PR avoids a larger refactor of `gen_windows_testing_job()` to make reviewing easier.

I've also prepared a [branch](https://github.com/Mbed-TLS/mbedtls-test/tree/dev/bensze01/mbed-tls-4-win-testing-new-ci) where this PR is rebased on-top of #218, and used this PR for the new-ci tests.

The `development` runs below detect that it supports the legacy build systems. This is indended, as the support is dropped in https://github.com/Mbed-TLS/mbedtls/pull/10382, which depends on this PR.

CI runs:
- development
  - [Internal CI][1]
  - [Open CI][4]
  - [New CI][7]
- mbedtls-3.6
  - [Internal CI][2]
  - [Open CI][5]
  - [New CI][8]
- https://github.com/Mbed-TLS/mbedtls/pull/10382
  - [Internal CI][3]
  - [Open CI][6]
  - [New CI][9]

[1]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/813/
[2]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/814/
[3]: https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-ci-testing/815/
[4]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/382/
[5]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/383/
[6]: https://mbedtls.trustedfirmware.org/job/mbedtls-release-ci-testing/384/
[7]: https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-release-ci-testing/22/
[8]: https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-release-ci-testing/23/
[9]: https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-release-ci-testing/24/