### PR TITLE
Work around bug in graph-view display

### DIFF
--- a/vars/gen_jobs.groovy
+++ b/vars/gen_jobs.groovy
@@ -134,7 +134,7 @@ Map<String, Callable<Void>> gen_docker_job(Map<String, Closure> hooks,
                     }
                 }
             }
-            stage(job_name) {
+            stage("${job_name}.inner") {
                 dir('src') {
                     writeFile file: 'steps.sh', text: """\
 #!/bin/sh
@@ -399,7 +399,7 @@ def gen_windows_testing_job(BranchInfo info, String toolchain) {
                     def exceptions = items.findResults { item ->
                         def job_name = (String) item.job_name
                         try {
-                            stage(job_name) {
+                            stage("${job_name}.inner") {
                                 common.report_errors(job_name) {
                                     def extra_args = ''
                                     if (toolchain != 'mingw') {


### PR DESCRIPTION
Fixes: #235 

The bug on the new graph view page described in #235 seems to be triggered by having nested nodes (calls to `stage` or `parallel`) with identical names.

Eg. the following will tigger the bug, as it does in `gen_docker_job()`:

```groovy
parallel foo: {
    stage('foo') {
        sh 'echo bar'
    }
}
```

This PR works around the bug by changing the name of the second inner stage in `gen_docker_job()`

CI run
- https://ci.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/37/pipeline-graph/
  -  (the failure is caused by the example Crypto PR used to demonstrate the issue in the analysis step, its not related to this PR)