### PR TITLE
Fix username in Ubuntu 24.04-based images

### DIFF
--- a/resources/docker_files/arm-compilers/Dockerfile
+++ b/resources/docker_files/arm-compilers/Dockerfile
@@ -150,8 +150,9 @@ RUN mkdir $ARMC5_BIN_DIR && \
 ARG ARMLMD_LICENSE_FILE=17010@aws-armlmd.license.aws.arm.com
 ENV ARMLMD_LICENSE_FILE=${ARMLMD_LICENSE_FILE}
 
-# Add user
-RUN useradd -m user
+# Remove the ubuntu(uid:1000) user and add our own - this matches the behaviour of older
+# Ubuntu base images and is required for User-based licenses to work.
+RUN userdel -r ubuntu && useradd -m user
 
 # Create workspace
 # Note: scripts/min_requirements.py need a writable

--- a/resources/docker_files/ubuntu-24.04/Dockerfile
+++ b/resources/docker_files/ubuntu-24.04/Dockerfile
@@ -351,8 +351,9 @@ RUN python3 -m pip config set global.progress_bar off && \
     # (either "user" or the developer who runs "docker -u ...").
     python3 -m pip config set global.break-system-packages true
 
-# Add user
-RUN useradd -m user
+# Remove the ubuntu(uid:1000) user and add our own - this matches the behaviour of older
+# Ubuntu base images and is required for User-based licenses to work.
+RUN userdel -r ubuntu && useradd -m user
 
 # Create workspace
 # FIXME: This should be /var/lib/build to use the host src directory as HOME


### PR DESCRIPTION
The Ubuntu 24.04 base image ships with a user named ubuntu as uid 1000, unlike
the older images.

This interferes with our User-based licenses, which was the cause of the failures produced by the arm-compilers image.

CI run:
  - [Mbed-TLS development][1]

[1]: https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-test-parametrized/91