### PR TITLE
Run outcome analysis in TF-PSA-Crypto if present

### DIFF
--- a/vars/analysis.groovy
+++ b/vars/analysis.groovy
@@ -268,7 +268,20 @@ fi
             }
         }
 
-        String script_in_docker = info.repo == 'mbedtls' ? "tests/scripts/analyze_outcomes.py '$outcomes_csv'" : ''
+        String script_in_docker = "tests/scripts/analyze_outcomes.py '$outcomes_csv'"
+        /* TF-PSA-Crypto started out without outcome analysis. Until it's
+         * present on all the branches, allow it to be missing and just skip
+         * outcome analysis.
+         */
+        if (info.repo != 'mbedtls') {
+            script_in_docker = """\
+if [ -e tests/scripts/analyze_outcomes.py ]; then
+  tests/scripts/analyze_outcomes.py '$outcomes_csv'
+else
+  echo "Skipping outcome analysis because this branch lacks tests/scripts/analyze_outcomes.py"
+fi
+"""
+        }
 
         Closure post_execution = {
             sh "[ -f '$outcomes_csv' ] && xz -0 -T0 '$outcomes_csv'"


### PR DESCRIPTION
During a transition period, while we're working on adding `analyze_outcomes.py`, we still pass if it's missing.

Test runs at 42e4cf8e2f6570a991db9a1024b4be91f2e997e7:

* Branch without `analyze_outcomes.py`: https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-restricted-release-ci-testing/23/ → passed with the expected message about skipping outcome analysis
* Branch with failing `analyze_outcomes.py` (https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/729): https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbedtls-restricted-release-ci-testing/22/pipeline-console/ → got the expected failure of `analyze_outcomes.py`
