### PR TITLE
Filter components tested in framework PRs

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -363,6 +363,16 @@ List<BranchInfo> get_branch_information(Collection<String> tls_branches, Collect
             info.all_sh_components = info.all_sh_components.findAll {
                 component, platform -> !component.startsWith('release')
             }
+
+            if (env.TARGET_REPO == 'mbedtls-framework') {
+                // Check if any components are prefixed with 'framework', and if so only run those.
+                def framework_components = info.all_sh_components.findAll {
+                    component, platform -> component.startsWith('framework')
+                }
+                if (framework_components) {
+                    info.all_sh_components = framework_components
+                }
+            }
         }
 
     }


### PR DESCRIPTION
With the filter in place, we only run components prefixed with 'framework' in framework PR jobs.

The filter is disabled if none of the components match it as a transition mechanism.